### PR TITLE
Fix: No need to update composer itself twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ cache:
 
 before_install:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
-  - travis_retry composer self-update
 
 install:
   - rm composer.lock


### PR DESCRIPTION
This PR

* [x] removes a redundant run of `composer self-update` on Travis

💁‍♂️ For reference, see

* https://travis-ci.org/doctrine/persistence/jobs/392427784#L480-L482
* https://travis-ci.org/doctrine/persistence/jobs/392427784#L510-L511