### PR TITLE
CI: Use Ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: false
 language: php
 


### PR DESCRIPTION
Ubuntu 16.04 is already available for usage: https://docs.travis-ci.com/user/reference/xenial/#using-xenial. Maybe we should do this across our other branches?