### PR TITLE
Metadata cache lifetime should be int

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -183,8 +183,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
                     foreach ($this->loadMetadata($realClassName) as $loadedClassName) {
                         $this->cacheDriver->save(
                             $loadedClassName . $this->cacheSalt,
-                            $this->loadedMetadata[$loadedClassName],
-                            null
+                            $this->loadedMetadata[$loadedClassName]
                         );
                     }
                 }


### PR DESCRIPTION
\Doctrine\Common\Cache\Cache::save does not accept null, but AbstractClassMetadataFactory does it.
The problem occurs with usage of \Doctrine\Common\Cache\PhpFileCache in 
```php
private function includeFileForId(string $id) : ?array
    {
        $fileName = $this->getFilename($id);

        // note: error suppression is still faster than `file_exists`, `is_file` and `is_readable`
        set_error_handler(self::$emptyErrorHandler);

        $value = include $fileName;

        restore_error_handler();

        if (! isset($value['lifetime'])) {
            return null;
        }

        return $value;
    }
```

on ```! isset($value['lifetime'])```