### PR TITLE
Fix Metadata Caching when it changes in EventListeners

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -175,10 +175,10 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
                     $this->loadedMetadata[$realClassName] = $cached;
                     $this->wakeupReflection($cached, $this->getReflectionService());
                 } else {
-                    $this->loadMetadata($className);
+                    $this->loadMetadata($realClassName);
                 }
             } else {
-                $this->loadMetadata($className);
+                $this->loadMetadata($realClassName);
             }
         } catch (MappingException $loadingException) {
             $fallbackMetadataResponse = $this->onNotFoundMetadata($className);
@@ -188,6 +188,10 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
             }
 
             $this->setMetadataFor($className, $fallbackMetadataResponse);
+        }
+
+        if ($className !== $realClassName) {
+            $this->setMetadataFor($className, $this->loadedMetadata[$realClassName]);
         }
 
         return $this->loadedMetadata[$className];

--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -36,7 +36,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     private $loadedMetadata = [];
 
     /** @var string[] */
-    protected $aliasesMap = [];
+    private $aliasesMap = [];
 
     /** @var bool */
     protected $initialized = false;
@@ -398,16 +398,15 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
             return $this->aliasesMap[$className];
         }
 
-        switch (true) {
-            case strpos($className, ':') !== false: // Check for namespace alias
-                [$namespaceAlias, $simpleClassName] = explode(':', $className, 2);
-                $realClassName                      = $this->getFqcnFromAlias($namespaceAlias, $simpleClassName);
-                break;
-            case $pos = strrpos($className, '\\' . Proxy::MARKER . '\\') !== false: // Check for namespace proxy
-                $realClassName = substr($className, $pos + Proxy::MARKER_LENGTH + 2);
-                break;
-            default:
-                $realClassName = $className;
+        $realClassName = $className;
+
+        if (strpos($className, ':') !== false) {
+            [$namespaceAlias, $simpleClassName] = explode(':', $className, 2);
+            $realClassName = $this->getFqcnFromAlias($namespaceAlias, $simpleClassName);
+        }
+
+        if ($pos = strrpos($className, '\\' . Proxy::MARKER . '\\') !== false) {
+            $realClassName = substr($className, $pos + Proxy::MARKER_LENGTH + 2);
         }
 
         $this->aliasesMap[$className] = $realClassName;

--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -155,20 +155,24 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      */
     public function getMetadataFor($className)
     {
-        $className = $this->getRealClassName($className);
-
         if (isset($this->loadedMetadata[$className])) {
             return $this->loadedMetadata[$className];
+        }
+
+        $realClassName = $this->getRealClassName($className);
+
+        if (isset($this->loadedMetadata[$realClassName])) {
+            // We do not have the alias name in the map, include it
+            return $this->loadedMetadata[$className] = $this->loadedMetadata[$realClassName];
         }
 
         $loadingException = null;
 
         try {
             if ($this->cacheDriver) {
-                $cached = $this->cacheDriver->fetch($className . $this->cacheSalt);
+                $cached = $this->cacheDriver->fetch($realClassName . $this->cacheSalt);
                 if ($cached instanceof ClassMetadata) {
-                    $this->loadedMetadata[$className] = $cached;
-
+                    $this->loadedMetadata[$realClassName] = $cached;
                     $this->wakeupReflection($cached, $this->getReflectionService());
                 } else {
                     $this->loadMetadata($className);
@@ -198,8 +202,6 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      */
     public function hasMetadataFor($className)
     {
-        $className = $this->getRealClassName($className);
-
         return isset($this->loadedMetadata[$className]);
     }
 
@@ -215,7 +217,6 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      */
     public function setMetadataFor($className, $class)
     {
-        $className                        = $this->getRealClassName($className);
         $this->loadedMetadata[$className] = $class;
 
         if ($this->cacheDriver === null) {

--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -402,10 +402,11 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
 
         if (strpos($className, ':') !== false) {
             [$namespaceAlias, $simpleClassName] = explode(':', $className, 2);
-            $realClassName = $this->getFqcnFromAlias($namespaceAlias, $simpleClassName);
+            $realClassName                      = $this->getFqcnFromAlias($namespaceAlias, $simpleClassName);
         }
 
-        if ($pos = strrpos($className, '\\' . Proxy::MARKER . '\\') !== false) {
+        $pos = strrpos($className, '\\' . Proxy::MARKER . '\\');
+        if ($pos !== false) {
             $realClassName = substr($className, $pos + Proxy::MARKER_LENGTH + 2);
         }
 

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -10,7 +10,7 @@ use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Common\Persistence\Mapping\MappingException;
 use Doctrine\Common\Persistence\Mapping\ReflectionService;
 use Doctrine\Tests\DoctrineTestCase;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 
 /**
@@ -140,7 +140,7 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
      */
     public function testWillIgnoreCacheEntriesThatAreNotMetadataInstances()
     {
-        /** @var Cache|PHPUnit_Framework_MockObject_MockObject $cacheDriver */
+        /** @var Cache|MockObject $cacheDriver */
         $cacheDriver = $this->createMock(Cache::class);
 
         $this->cmf->setCacheDriver($cacheDriver);
@@ -150,7 +150,7 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         /** @var ClassMetadata $metadata */
         $metadata = $this->createMock(ClassMetadata::class);
 
-        /** @var PHPUnit_Framework_MockObject_MockObject|stdClass|callable $fallbackCallback */
+        /** @var MockObject|stdClass|callable $fallbackCallback */
         $fallbackCallback = $this->getMockBuilder(stdClass::class)->setMethods(['__invoke'])->getMock();
 
         $fallbackCallback->expects(self::any())->method('__invoke')->willReturn($metadata);
@@ -158,6 +158,35 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $this->cmf->fallbackCallback = $fallbackCallback;
 
         self::assertSame($metadata, $this->cmf->getMetadataFor('Foo'));
+    }
+
+    public function testFallbackMetadataShouldBeCached() : void
+    {
+        /** @var Cache|MockObject $cacheDriver */
+        $cacheDriver = $this->createMock(Cache::class);
+        $cacheDriver->expects(self::once())->method('save');
+
+        $this->cmf->setCacheDriver($cacheDriver);
+
+        $classMetadata = $this->createMock(ClassMetadata::class);
+
+        $this->cmf->fallbackCallback = static function () use ($classMetadata) {
+            return $classMetadata;
+        };
+
+        $this->cmf->getMetadataFor('Foo');
+    }
+
+    public function testSetMetadataForShouldUpdateCache() : void
+    {
+        /** @var Cache|MockObject $cacheDriver */
+        $cacheDriver = $this->createMock(Cache::class);
+        $cacheDriver->expects(self::once())->method('save');
+
+        $this->cmf->setCacheDriver($cacheDriver);
+
+        $classMetadata = $this->createMock(ClassMetadata::class);
+        $this->cmf->setMetadataFor('Foo', $classMetadata);
     }
 }
 


### PR DESCRIPTION
I've closed PR https://github.com/doctrine/persistence/pull/21 and created new one, because that PR is targeted on master.

This PR fixed 2 bugs:

1. Using https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/cookbook/resolve-target-entity-listener.html with metadata cache is not working, because ResolveTargetEntityListener calls setMetadataFor without any effect on generated cache.
2. Fallback metadata is not caching now.