### PR TITLE
CI: Test against PHP 7.4snapshot instead of nightly (8.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - nightly
+  - 7.4snapshot
 
 cache:
   directories:
@@ -24,7 +24,7 @@ script:
 
 jobs:
   allow_failures:
-    - php: nightly
+    - php: 7.4snapshot
 
   include:
     - stage: Test


### PR DESCRIPTION
Backport CI against 7.4 to 1.x.