### PR TITLE
Use getManagerForClass in getRepository

### DIFF
--- a/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
@@ -210,7 +210,9 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
      */
     public function getRepository($persistentObjectName, $persistentManagerName = null)
     {
-        return $this->getManager($persistentManagerName)->getRepository($persistentObjectName);
+        return $this
+            ->selectManager($persistentObjectName, $persistentManagerName)
+            ->getRepository($persistentObjectName);
     }
 
     /**
@@ -231,5 +233,14 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
         $this->resetService($this->managers[$name]);
 
         return $this->getManager($name);
+    }
+
+    private function selectManager(string $persistentObjectName, ?string $persistentManagerName = null) : ?ObjectManager
+    {
+        if ($persistentManagerName !== null) {
+            return $this->getManager($persistentManagerName);
+        }
+
+        return $this->getManagerForClass($persistentObjectName) ?? $this->getManager();
     }
 }

--- a/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
@@ -7,8 +7,11 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ObjectManagerAware;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Common\Persistence\Proxy;
 use Doctrine\Tests\Common\Persistence\Mapping\TestClassMetadataFactory;
 use Doctrine\Tests\DoctrineTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionException;
 use function call_user_func;
 
@@ -78,12 +81,95 @@ class ManagerRegistryTest extends DoctrineTestCase
         self::assertNotSame($manager, $newManager);
     }
 
+    public function testGetRepository()
+    {
+        $repository = $this->createMock(ObjectRepository::class);
+
+        /** @var MockObject $defaultManager */
+        $defaultManager = $this->mr->getManager();
+        $defaultManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with($this->equalTo(TestObject::class))
+            ->will($this->returnValue($repository));
+
+        self::assertSame($repository, $this->mr->getRepository(TestObject::class));
+    }
+
+    public function testGetRepositoryWithSpecificManagerName()
+    {
+        $this->mr = new TestManagerRegistry(
+            'ORM',
+            ['default' => 'default_connection'],
+            ['default' => 'default_manager', 'other' => 'other_manager'],
+            'default',
+            'default',
+            ObjectManagerAware::class,
+            $this->getManagerFactory()
+        );
+
+        $repository = $this->createMock(ObjectRepository::class);
+
+        /** @var MockObject $defaultManager */
+        $defaultManager = $this->mr->getManager();
+        $defaultManager
+            ->expects($this->never())
+            ->method('getRepository');
+
+        /** @var MockObject $otherManager */
+        $otherManager = $this->mr->getManager('other');
+        $otherManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with($this->equalTo(TestObject::class))
+            ->will($this->returnValue($repository));
+
+        self::assertSame($repository, $this->mr->getRepository(TestObject::class, 'other'));
+    }
+
+    public function testGetRepositoryWithManagerDetection()
+    {
+        $this->mr = new TestManagerRegistry(
+            'ORM',
+            ['default' => 'default_connection'],
+            ['default' => 'default_manager', 'other' => 'other_manager'],
+            'default',
+            'default',
+            Proxy::class,
+            $this->getManagerFactory()
+        );
+
+        $repository = $this->createMock(ObjectRepository::class);
+
+        /** @var MockObject $defaultManager */
+        $defaultManager = $this->mr->getManager();
+        $defaultManager
+            ->expects($this->never())
+            ->method('getRepository');
+
+        /** @var MockObject $otherManager */
+        $otherManager = $this->mr->getManager('other');
+        $otherManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with($this->equalTo(OtherTestObject::class))
+            ->will($this->returnValue($repository));
+
+        self::assertSame($repository, $this->mr->getRepository(OtherTestObject::class));
+    }
+
     private function getManagerFactory()
     {
-        return function () {
+        return function (string $name) {
             $mock     = $this->createMock(ObjectManager::class);
             $driver   = $this->createMock(MappingDriver::class);
             $metadata = $this->createMock(ClassMetadata::class);
+
+            $metadata
+                ->expects($this->any())
+                ->method('getName')
+                ->willReturn($name === 'other_manager' ? OtherTestObject::class : TestObject::class);
+
             $mock->method('getMetadataFactory')->willReturn(new TestClassMetadataFactory($driver, $metadata));
 
             return $mock;
@@ -120,7 +206,7 @@ class TestManagerRegistry extends AbstractManagerRegistry
     protected function getService($name)
     {
         if (! isset($this->services[$name])) {
-            $this->services[$name] = call_user_func($this->managerFactory);
+            $this->services[$name] = call_user_func($this->managerFactory, $name);
         }
 
         return $this->services[$name];

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -4,11 +4,9 @@ namespace Doctrine\Tests\Common\Persistence\Mapping;
 
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache;
-use Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Common\Persistence\Mapping\MappingException;
-use Doctrine\Common\Persistence\Mapping\ReflectionService;
 use Doctrine\Tests\DoctrineTestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use stdClass;
@@ -158,76 +156,6 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $this->cmf->fallbackCallback = $fallbackCallback;
 
         self::assertSame($metadata, $this->cmf->getMetadataFor('Foo'));
-    }
-}
-
-class TestClassMetadataFactory extends AbstractClassMetadataFactory
-{
-    /** @var MappingDriver */
-    public $driver;
-
-    /** @var ClassMetadata|null */
-    public $metadata;
-
-    /** @var callable|null */
-    public $fallbackCallback;
-
-    public function __construct($driver, $metadata)
-    {
-        $this->driver   = $driver;
-        $this->metadata = $metadata;
-    }
-
-    /**
-     * @param string[] $nonSuperclassParents
-     */
-    protected function doLoadMetadata($class, $parent, $rootEntityFound, array $nonSuperclassParents)
-    {
-    }
-
-    protected function getFqcnFromAlias($namespaceAlias, $simpleClassName)
-    {
-        return __NAMESPACE__ . '\\' . $simpleClassName;
-    }
-
-    protected function initialize()
-    {
-    }
-
-    protected function newClassMetadataInstance($className)
-    {
-        return $this->metadata;
-    }
-
-    protected function getDriver()
-    {
-        return $this->driver;
-    }
-    protected function wakeupReflection(ClassMetadata $class, ReflectionService $reflService)
-    {
-    }
-
-    protected function initializeReflection(ClassMetadata $class, ReflectionService $reflService)
-    {
-    }
-
-    protected function isEntity(ClassMetadata $class)
-    {
-        return true;
-    }
-
-    protected function onNotFoundMetadata($className)
-    {
-        if (! $this->fallbackCallback) {
-            return null;
-        }
-
-        return ($this->fallbackCallback)();
-    }
-
-    public function isTransient($class)
-    {
-        return true;
     }
 }
 

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/TestClassMetadataFactory.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/TestClassMetadataFactory.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Persistence\Mapping;
+
+use Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Common\Persistence\Mapping\ReflectionService;
+
+class TestClassMetadataFactory extends AbstractClassMetadataFactory
+{
+    /** @var MappingDriver */
+    public $driver;
+
+    /** @var ClassMetadata|null */
+    public $metadata;
+
+    /** @var callable|null */
+    public $fallbackCallback;
+
+    public function __construct(MappingDriver $driver, ?ClassMetadata $metadata)
+    {
+        $this->driver   = $driver;
+        $this->metadata = $metadata;
+    }
+
+    /**
+     * @param string[] $nonSuperclassParents
+     */
+    protected function doLoadMetadata($class, $parent, $rootEntityFound, array $nonSuperclassParents)
+    {
+    }
+
+    protected function getFqcnFromAlias($namespaceAlias, $simpleClassName)
+    {
+        return __NAMESPACE__ . '\\' . $simpleClassName;
+    }
+
+    protected function initialize()
+    {
+    }
+
+    protected function newClassMetadataInstance($className)
+    {
+        return $this->metadata;
+    }
+
+    protected function getDriver()
+    {
+        return $this->driver;
+    }
+    protected function wakeupReflection(ClassMetadata $class, ReflectionService $reflService)
+    {
+    }
+
+    protected function initializeReflection(ClassMetadata $class, ReflectionService $reflService)
+    {
+    }
+
+    protected function isEntity(ClassMetadata $class)
+    {
+        return true;
+    }
+
+    protected function onNotFoundMetadata($className)
+    {
+        if (! $this->fallbackCallback) {
+            return null;
+        }
+
+        return ($this->fallbackCallback)();
+    }
+
+    public function isTransient($class)
+    {
+        $name = $this->metadata->getName();
+        return $class !== $name;
+    }
+}

--- a/tests/Doctrine/Tests/Common/Persistence/OtherTestObject.php
+++ b/tests/Doctrine/Tests/Common/Persistence/OtherTestObject.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Persistence;
+
+use Doctrine\Common\Persistence\PersistentObject;
+
+class OtherTestObject extends PersistentObject
+{
+    /** @var int */
+    protected $id = 1;
+}

--- a/tests/Doctrine/Tests/Common/Persistence/PersistentObjectTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/PersistentObjectTest.php
@@ -164,21 +164,6 @@ class PersistentObjectTest extends DoctrineTestCase
     }
 }
 
-class TestObject extends PersistentObject
-{
-    /** @var int */
-    protected $id = 1;
-
-    /** @var string */
-    protected $name = 'beberlei';
-
-    /** @var TestObject */
-    protected $parent;
-
-    /** @var TestObject */
-    protected $children;
-}
-
 class TestObjectMetadata implements ClassMetadata
 {
     public function getAssociationMappedByTargetField($assocName)

--- a/tests/Doctrine/Tests/Common/Persistence/TestObject.php
+++ b/tests/Doctrine/Tests/Common/Persistence/TestObject.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Persistence;
+
+use Doctrine\Common\Persistence\PersistentObject;
+
+class TestObject extends PersistentObject
+{
+    /** @var int */
+    protected $id = 1;
+
+    /** @var string */
+    protected $name = 'beberlei';
+
+    /** @var TestObject */
+    protected $parent;
+
+    /** @var TestObject */
+    protected $children;
+}


### PR DESCRIPTION
Fixes #45. Targeting 1.1.x since it's unexpected behaviour (thus considered a bug).

This changes logic in `getRepository` to use `getManagerForClass` if no repository was specified. Basically, instead of just using a specific manager (falling back to the default if none was given), we now use the following process:
* If a `persistentManagerName` is given, we always call `getRepository` on that manager
* If no `persistentManagerName` is given, we call `getManagerForClass` to find the first object manager that manages the given object class
* If the previous step did not yield an object manager, we fall back to the default object manager.

Note: changes from the first commit were necessary to be able to run tests standalone - somehow the PHPUnit config did not play nice with that.