### PR TITLE
Remove php 7.4 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: php
 php:
   - 7.2
   - 7.3
-  - 7.4snapshot
 
 cache:
   directories:


### PR DESCRIPTION
PHP 7.4 snapshot/nightly is failing on travis so remove it for now.