### PR TITLE
Deprecate ObjectManager::merge() and ObjectManager::detach()

### DIFF
--- a/UPGRADE-1.2.md
+++ b/UPGRADE-1.2.md
@@ -1,0 +1,5 @@
+UPGRADE FROM 1.x to 1.2
+=======================
+
+* Deprecated `ObjectManager::merge()`. Please handle merge operations in your application instead.
+* Deprecated `ObjectManager::detach()`. Please use `ObjectManager::clear()` instead.

--- a/lib/Doctrine/Common/Persistence/ObjectManager.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManager.php
@@ -52,6 +52,10 @@ interface ObjectManager
      * of this ObjectManager and returns the managed copy of the object.
      * The object passed to merge will not become associated/managed with this ObjectManager.
      *
+     * @deprecated Merge operation is deprecated and will be removed in Persistence 2.0.
+     *             Merging should be part of the business domain of an application rather than
+     *             a generic operation of ObjectManager.
+     *
      * @param object $object
      *
      * @return object
@@ -74,6 +78,9 @@ interface ObjectManager
      * (including removal of the object), will not be synchronized to the database.
      * Objects which previously referenced the detached object will continue to
      * reference it.
+     *
+     * @deprecated Detach operation is deprecated and will be removed in Persistence 2.0. Please use
+     *             {@see ObjectManager::clear()} instead.
      *
      * @param object $object The object to detach.
      *


### PR DESCRIPTION
Work originally started in #47

Added deprecation for `ObjectManager::merge()` and `ObjectManager::detach()` ahead of their removal in 2.0 and ORM 3.0.

More context in:
* https://github.com/doctrine/orm/blob/ebb53acda96e304a6f91d4a5a2d76378a4e1d210/UPGRADE.md#bc-break-removed-entitymanagermerge-and-entitymanagerdetach-methods
* https://github.com/doctrine/orm/pull/1577