### PR TITLE
Remove dupes in FileDriver::getAllClassNames

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\Mapping\MappingException;
 use function array_keys;
 use function array_merge;
+use function array_unique;
 use function is_file;
 use function str_replace;
 
@@ -126,10 +127,10 @@ abstract class FileDriver implements MappingDriver
             return (array) $this->locator->getAllClassNames($this->globalBasename);
         }
 
-        return array_merge(
+        return array_unique(array_merge(
             array_keys($this->classCache),
             (array) $this->locator->getAllClassNames($this->globalBasename)
-        );
+        ));
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
@@ -101,6 +101,22 @@ class FileDriverTest extends DoctrineTestCase
         self::assertSame(['stdGlobal', 'stdGlobal2', 'stdClass'], $classNames);
     }
 
+    public function testGetAllClassNamesBothSourcesNoDupes() : void
+    {
+        $locator = $this->newLocator();
+        $locator->expects($this->once())
+                ->method('getAllClassNames')
+                ->with($this->equalTo('global'))
+                ->willReturn(['stdClass']);
+        $driver = new TestFileDriver($locator);
+        $driver->setGlobalBasename('global');
+
+        $driver->getElement('stdClass');
+        $classNames = $driver->getAllClassNames();
+
+        self::assertSame(['stdGlobal', 'stdGlobal2', 'stdClass'], $classNames);
+    }
+
     public function testIsNotTransient()
     {
         $locator = $this->newLocator();


### PR DESCRIPTION
Continuing https://github.com/doctrine/persistence/pull/44, author is unlikely to rebase. Just re-approve needed