### PR TITLE
Fix wrong return type hint for selectManager

### DIFF
--- a/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
@@ -235,7 +235,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
         return $this->getManager($name);
     }
 
-    private function selectManager(string $persistentObjectName, ?string $persistentManagerName = null) : ?ObjectManager
+    private function selectManager(string $persistentObjectName, ?string $persistentManagerName = null) : ObjectManager
     {
         if ($persistentManagerName !== null) {
             return $this->getManager($persistentManagerName);


### PR DESCRIPTION
As indicated by @ostrolucky in https://github.com/doctrine/persistence/pull/50#discussion_r276823272, the method can't return `null` unless `getService` violates its contract and returns `null`. Fixing the type hint in 1.1.x makes sense.