### PR TITLE
RFC: Add optional orderBy parameter to findAll

### DIFF
--- a/lib/Doctrine/Persistence/ObjectRepository.php
+++ b/lib/Doctrine/Persistence/ObjectRepository.php
@@ -27,7 +27,7 @@ interface ObjectRepository
      *
      * @return array<int, object> The objects.
      */
-    public function findAll(?array $orderBy = null) : array;
+    public function findAll(?array $orderBy = []) : array;
 
     /**
      * Finds objects by a set of criteria.

--- a/lib/Doctrine/Persistence/ObjectRepository.php
+++ b/lib/Doctrine/Persistence/ObjectRepository.php
@@ -27,7 +27,7 @@ interface ObjectRepository
      *
      * @return array<int, object> The objects.
      */
-    public function findAll(?array $orderBy) : array;
+    public function findAll(?array $orderBy = null) : array;
 
     /**
      * Finds objects by a set of criteria.

--- a/lib/Doctrine/Persistence/ObjectRepository.php
+++ b/lib/Doctrine/Persistence/ObjectRepository.php
@@ -23,9 +23,11 @@ interface ObjectRepository
     /**
      * Finds all objects in the repository.
      *
+     * @param array<string, string> $orderBy
+     *
      * @return array<int, object> The objects.
      */
-    public function findAll() : array;
+    public function findAll(?array $orderBy) : array;
 
     /**
      * Finds objects by a set of criteria.


### PR DESCRIPTION
In this patch I want to discuss the possibility of adding an optional parameter to the `findAll` method, that IMO makes sense to be there: `$orderBy`. 

When one needs to fetch the data sorted differently than the default method `findAll` is of no use and one has to use `findBy([], $orderBy)`, which makes it slightly less readable as there are no filters being applied, but rather it is used only for sorting.  Said calls then can be changed to `findAll($orderBy)`

If the maintainers agree that this is a positive change then I can also send the corresponding PR for `doctrine/orm` and any documentation changes.