### PR TITLE
AbstractManagerRegistry: Treat defaultManager first for getManagerForClass

### DIFF
--- a/lib/Doctrine/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Persistence/AbstractManagerRegistry.php
@@ -184,6 +184,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
         }
 
         if($this->defaultManager) {
+            /** @var ObjectManager $manager */
           $manager = $this->getManager($this->defaultManager);
 
           if (! $manager->getMetadataFactory()->isTransient($class)) {

--- a/lib/Doctrine/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Persistence/AbstractManagerRegistry.php
@@ -183,6 +183,14 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
             $class = $parentClass->getName();
         }
 
+        if($this->defaultManager) {
+          $manager = $this->getManager($this->defaultManager);
+
+          if (! $manager->getMetadataFactory()->isTransient($class)) {
+            return $manager;
+          }
+        }
+
         foreach ($this->managers as $id) {
             /** @var ObjectManager $manager */
             $manager = $this->getService($id);

--- a/lib/Doctrine/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Persistence/AbstractManagerRegistry.php
@@ -183,13 +183,13 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
             $class = $parentClass->getName();
         }
 
-        if($this->defaultManager) {
+        if (!empty($this->defaultManager)) {
             /** @var ObjectManager $manager */
-          $manager = $this->getManager($this->defaultManager);
+            $manager = $this->getManager($this->defaultManager);
 
-          if (! $manager->getMetadataFactory()->isTransient($class)) {
-            return $manager;
-          }
+            if (! $manager->getMetadataFactory()->isTransient($class)) {
+                return $manager;
+            }
         }
 
         foreach ($this->managers as $id) {


### PR DESCRIPTION
I propose this PR to fix an issue: when you have two managers, and the default is set as second, the first manager is returned.