### PR TITLE
Remove return types from all interfaces

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -17,4 +17,5 @@ ActiveRecord style functionality.
 
 ## Strict Typing
 
-Proper type hints have been added to all method signatures and strict types have been enabled.
+Type declarations have been enabled for all parameters and strict types have been enabled.
+Return type declarations will be added in the next major release.

--- a/lib/Doctrine/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Persistence/AbstractManagerRegistry.php
@@ -60,9 +60,9 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
      *
      * @param string $name The name of the service.
      *
-     * @return object The instance of the given service.
+     * @return ObjectManager The instance of the given service.
      */
-    abstract protected function getService(string $name) : object;
+    abstract protected function getService(string $name);
 
     /**
      * Resets the given services.
@@ -70,13 +70,17 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
      * A service in this context is connection or a manager instance.
      *
      * @param string $name The name of the service.
+     *
+     * @return void
      */
-    abstract protected function resetService(string $name) : void;
+    abstract protected function resetService(string $name);
 
     /**
      * Gets the name of the registry.
+     *
+     * @return string
      */
-    public function getName() : string
+    public function getName()
     {
         return $this->name;
     }
@@ -84,7 +88,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getConnection(?string $name = null) : object
+    public function getConnection(?string $name = null)
     {
         if ($name === null) {
             $name = $this->defaultConnection;
@@ -102,7 +106,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getConnectionNames() : array
+    public function getConnectionNames()
     {
         return $this->connections;
     }
@@ -110,7 +114,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getConnections() : array
+    public function getConnections()
     {
         $connections = [];
         foreach ($this->connections as $name => $id) {
@@ -123,7 +127,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getDefaultConnectionName() : string
+    public function getDefaultConnectionName()
     {
         return $this->defaultConnection;
     }
@@ -131,7 +135,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getDefaultManagerName() : string
+    public function getDefaultManagerName()
     {
         return $this->defaultManager;
     }
@@ -141,7 +145,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
      *
      * @throws InvalidArgumentException
      */
-    public function getManager(?string $name = null) : ObjectManager
+    public function getManager(?string $name = null)
     {
         if ($name === null) {
             $name = $this->defaultManager;
@@ -153,16 +157,13 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
             );
         }
 
-        /** @var ObjectManager $objectManager */
-        $objectManager = $this->getService($this->managers[$name]);
-
-        return $objectManager;
+        return $this->getService($this->managers[$name]);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getManagerForClass(string $class) : ?ObjectManager
+    public function getManagerForClass(string $class)
     {
         // Check for namespace alias
         if (strpos($class, ':') !== false) {
@@ -184,7 +185,6 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
         }
 
         foreach ($this->managers as $id) {
-            /** @var ObjectManager $manager */
             $manager = $this->getService($id);
 
             if (! $manager->getMetadataFactory()->isTransient($class)) {
@@ -198,7 +198,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getManagerNames() : array
+    public function getManagerNames()
     {
         return $this->managers;
     }
@@ -206,7 +206,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getManagers() : array
+    public function getManagers()
     {
         $managers = [];
 
@@ -226,7 +226,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     public function getRepository(
         string $persistentObjectName,
         ?string $persistentManagerName = null
-    ) : ObjectRepository {
+    ) {
         return $this
             ->selectManager($persistentObjectName, $persistentManagerName)
             ->getRepository($persistentObjectName);
@@ -235,7 +235,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function resetManager(?string $name = null) : ObjectManager
+    public function resetManager(?string $name = null)
     {
         if ($name === null) {
             $name = $this->defaultManager;

--- a/lib/Doctrine/Persistence/ConnectionRegistry.php
+++ b/lib/Doctrine/Persistence/ConnectionRegistry.php
@@ -14,26 +14,28 @@ interface ConnectionRegistry
      *
      * @return string The default connection name.
      */
-    public function getDefaultConnectionName() : string;
+    public function getDefaultConnectionName();
 
     /**
      * Gets the named connection.
      *
      * @param string $name The connection name (null for the default one).
+     *
+     * @return object
      */
-    public function getConnection(?string $name = null) : object;
+    public function getConnection(?string $name = null);
 
     /**
      * Gets an array of all registered connections.
      *
      * @return array<string, object> An array of Connection instances.
      */
-    public function getConnections() : array;
+    public function getConnections();
 
     /**
      * Gets all connection names.
      *
      * @return array<string, string> An array of connection names.
      */
-    public function getConnectionNames() : array;
+    public function getConnectionNames();
 }

--- a/lib/Doctrine/Persistence/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/Persistence/Event/LifecycleEventArgs.php
@@ -29,24 +29,30 @@ class LifecycleEventArgs extends EventArgs
      * Retrieves the associated entity.
      *
      * @deprecated
+     *
+     * @return object
      */
-    public function getEntity() : object
+    public function getEntity()
     {
         return $this->object;
     }
 
     /**
      * Retrieves the associated object.
+     *
+     * @return object
      */
-    public function getObject() : object
+    public function getObject()
     {
         return $this->object;
     }
 
     /**
      * Retrieves the associated ObjectManager.
+     *
+     * @return ObjectManager
      */
-    public function getObjectManager() : ObjectManager
+    public function getObjectManager()
     {
         return $this->objectManager;
     }

--- a/lib/Doctrine/Persistence/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/Persistence/Event/LoadClassMetadataEventArgs.php
@@ -27,16 +27,20 @@ class LoadClassMetadataEventArgs extends EventArgs
 
     /**
      * Retrieves the associated ClassMetadata.
+     *
+     * @return ClassMetadata
      */
-    public function getClassMetadata() : ClassMetadata
+    public function getClassMetadata()
     {
         return $this->classMetadata;
     }
 
     /**
      * Retrieves the associated ObjectManager.
+     *
+     * @return ObjectManager
      */
-    public function getObjectManager() : ObjectManager
+    public function getObjectManager()
     {
         return $this->objectManager;
     }

--- a/lib/Doctrine/Persistence/Event/ManagerEventArgs.php
+++ b/lib/Doctrine/Persistence/Event/ManagerEventArgs.php
@@ -22,8 +22,10 @@ class ManagerEventArgs extends EventArgs
 
     /**
      * Retrieves the associated ObjectManager.
+     *
+     * @return ObjectManager
      */
-    public function getObjectManager() : ObjectManager
+    public function getObjectManager()
     {
         return $this->objectManager;
     }

--- a/lib/Doctrine/Persistence/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/Persistence/Event/OnClearEventArgs.php
@@ -30,24 +30,30 @@ class OnClearEventArgs extends EventArgs
 
     /**
      * Retrieves the associated ObjectManager.
+     *
+     * @return ObjectManager
      */
-    public function getObjectManager() : ObjectManager
+    public function getObjectManager()
     {
         return $this->objectManager;
     }
 
     /**
      * Returns the name of the entity class that is cleared, or null if all are cleared.
+     *
+     * @return string|null
      */
-    public function getEntityClass() : ?string
+    public function getEntityClass()
     {
         return $this->entityClass;
     }
 
     /**
      * Returns whether this event clears all entities.
+     *
+     * @return bool
      */
-    public function clearsAllEntities() : bool
+    public function clearsAllEntities()
     {
         return $this->entityClass === null;
     }

--- a/lib/Doctrine/Persistence/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/Persistence/Event/PreUpdateEventArgs.php
@@ -32,15 +32,17 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      *
      * @return array<string, array<int, mixed>>
      */
-    public function getEntityChangeSet() : array
+    public function getEntityChangeSet()
     {
         return $this->entityChangeSet;
     }
 
     /**
      * Checks if field has a changeset.
+     *
+     * @return bool
      */
-    public function hasChangedField(string $field) : bool
+    public function hasChangedField(string $field)
     {
         return isset($this->entityChangeSet[$field]);
     }
@@ -73,8 +75,10 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      * Sets the new value of this field.
      *
      * @param mixed $value
+     *
+     * @return void
      */
-    public function setNewValue(string $field, $value) : void
+    public function setNewValue(string $field, $value)
     {
         $this->assertValidField($field);
 
@@ -84,9 +88,11 @@ class PreUpdateEventArgs extends LifecycleEventArgs
     /**
      * Asserts the field exists in changeset.
      *
+     * @return void
+     *
      * @throws InvalidArgumentException
      */
-    private function assertValidField(string $field) : void
+    private function assertValidField(string $field)
     {
         if (! isset($this->entityChangeSet[$field])) {
             throw new InvalidArgumentException(sprintf(

--- a/lib/Doctrine/Persistence/ManagerRegistry.php
+++ b/lib/Doctrine/Persistence/ManagerRegistry.php
@@ -14,21 +14,23 @@ interface ManagerRegistry extends ConnectionRegistry
      *
      * @return string The default object manager name.
      */
-    public function getDefaultManagerName() : string;
+    public function getDefaultManagerName();
 
     /**
      * Gets a named object manager.
      *
      * @param string $name The object manager name (null for the default one).
+     *
+     * @return ObjectManager
      */
-    public function getManager(?string $name = null) : ObjectManager;
+    public function getManager(?string $name = null);
 
     /**
      * Gets an array of all registered object managers.
      *
      * @return array<string, ObjectManager> An array of ObjectManager instances
      */
-    public function getManagers() : array;
+    public function getManagers();
 
     /**
      * Resets a named object manager.
@@ -44,8 +46,10 @@ interface ManagerRegistry extends ConnectionRegistry
      * to avoid this problem.
      *
      * @param string|null $name The object manager name (null for the default one).
+     *
+     * @return ObjectManager
      */
-    public function resetManager(?string $name = null) : ObjectManager;
+    public function resetManager(?string $name = null);
 
     /**
      * Resolves a registered namespace alias to the full namespace.
@@ -56,30 +60,34 @@ interface ManagerRegistry extends ConnectionRegistry
      *
      * @return string The full namespace.
      */
-    public function getAliasNamespace(string $alias) : string;
+    public function getAliasNamespace(string $alias);
 
     /**
      * Gets all object manager names.
      *
      * @return array<string, string> An array of object manager names.
      */
-    public function getManagerNames() : array;
+    public function getManagerNames();
 
     /**
      * Gets the ObjectRepository for a persistent object.
      *
      * @param string $persistentObject      The name of the persistent object.
      * @param string $persistentManagerName The object manager name (null for the default one).
+     *
+     * @return ObjectRepository
      */
     public function getRepository(
         string $persistentObject,
         ?string $persistentManagerName = null
-    ) : ObjectRepository;
+    );
 
     /**
      * Gets the object manager associated with a given class.
      *
      * @param string $class A persistent object class name.
+     *
+     * @return ObjectManager|null
      */
-    public function getManagerForClass(string $class) : ?ObjectManager;
+    public function getManagerForClass(string $class);
 }

--- a/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -45,16 +45,20 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
 
     /**
      * Sets the cache driver used by the factory to cache ClassMetadata instances.
+     *
+     * @return void
      */
-    public function setCacheDriver(?Cache $cacheDriver = null) : void
+    public function setCacheDriver(?Cache $cacheDriver = null)
     {
         $this->cacheDriver = $cacheDriver;
     }
 
     /**
      * Gets the cache driver used by the factory to cache ClassMetadata instances.
+     *
+     * @return Cache|null
      */
-    public function getCacheDriver() : ?Cache
+    public function getCacheDriver()
     {
         return $this->cacheDriver;
     }
@@ -64,7 +68,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return ClassMetadata[]
      */
-    public function getLoadedMetadata() : array
+    public function getLoadedMetadata()
     {
         return $this->loadedMetadata;
     }
@@ -75,7 +79,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return array<int, ClassMetadata> The ClassMetadata instances of all mapped classes.
      */
-    public function getAllMetadata() : array
+    public function getAllMetadata()
     {
         if (! $this->initialized) {
             $this->initialize();
@@ -93,54 +97,68 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     /**
      * Lazy initialization of this stuff, especially the metadata driver,
      * since these are not needed at all when a metadata cache is active.
+     *
+     * @return void
      */
-    abstract protected function initialize() : void;
+    abstract protected function initialize();
 
     /**
      * Gets the fully qualified class-name from the namespace alias.
+     *
+     * @return string
      */
     abstract protected function getFqcnFromAlias(
         string $namespaceAlias,
         string $simpleClassName
-    ) : string;
+    );
 
     /**
      * Returns the mapping driver implementation.
+     *
+     * @return MappingDriver
      */
-    abstract protected function getDriver() : MappingDriver;
+    abstract protected function getDriver();
 
     /**
      * Wakes up reflection after ClassMetadata gets unserialized from cache.
+     *
+     * @return void
      */
     abstract protected function wakeupReflection(
         ClassMetadata $class,
         ReflectionService $reflService
-    ) : void;
+    );
 
     /**
      * Initializes Reflection after ClassMetadata was constructed.
+     *
+     * @return void
      */
     abstract protected function initializeReflection(
         ClassMetadata $class,
         ReflectionService $reflService
-    ) : void;
+    );
 
     /**
      * Checks whether the class metadata is an entity.
      *
      * This method should return false for mapped superclasses or embedded classes.
+     *
+     * @return bool
      */
-    abstract protected function isEntity(ClassMetadata $class) : bool;
+    abstract protected function isEntity(ClassMetadata $class);
 
     /**
      * Gets the class metadata descriptor for a class.
      *
      * @param string $className The name of the class.
      *
+     * @return ClassMetadata
+     *
      * @throws ReflectionException
      * @throws MappingException
      */
-    public function getMetadataFor(string $className) : ClassMetadata
+    public function getMetadataFor(string $className)
     {
         if (isset($this->loadedMetadata[$className])) {
             return $this->loadedMetadata[$className];
@@ -204,7 +222,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return bool TRUE if the metadata of the class in question is already loaded, FALSE otherwise.
      */
-    public function hasMetadataFor(string $className) : bool
+    public function hasMetadataFor(string $className)
     {
         return isset($this->loadedMetadata[$className]);
     }
@@ -213,8 +231,10 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * Sets the metadata descriptor for a specific class.
      *
      * NOTE: This is only useful in very special cases, like when generating proxy classes.
+     *
+     * @return void
      */
-    public function setMetadataFor(string $className, ClassMetadata $class) : void
+    public function setMetadataFor(string $className, ClassMetadata $class)
     {
         $this->loadedMetadata[$className] = $class;
     }
@@ -224,7 +244,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return array<int, string>
      */
-    protected function getParentClasses(string $name) : array
+    protected function getParentClasses(string $name)
     {
         // Collect parent classes, ignoring transient (not-mapped) classes.
         $parentClasses = [];
@@ -257,7 +277,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return array<int, string>
      */
-    protected function loadMetadata(string $name) : array
+    protected function loadMetadata(string $name)
     {
         if (! $this->initialized) {
             $this->initialize();
@@ -314,8 +334,10 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * Provides a fallback hook for loading metadata when loading failed due to reflection/mapping exceptions
      *
      * Override this method to implement a fallback strategy for failed metadata loading
+     *
+     * @return ClassMetadata|null
      */
-    protected function onNotFoundMetadata(string $className) : ?ClassMetadata
+    protected function onNotFoundMetadata(string $className)
     {
         return null;
     }
@@ -324,23 +346,27 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * Actually loads the metadata from the underlying metadata.
      *
      * @param array<int, string> $nonSuperclassParents All parent class names that are not marked as mapped superclasses.
+     *
+     * @return void
      */
     abstract protected function doLoadMetadata(
         ClassMetadata $class,
         ?ClassMetadata $parent,
         bool $rootEntityFound,
         array $nonSuperclassParents
-    ) : void;
+    );
 
     /**
      * Creates a new ClassMetadata instance for the given class name.
+     *
+     * @return ClassMetadata
      */
-    abstract protected function newClassMetadataInstance(string $className) : ClassMetadata;
+    abstract protected function newClassMetadataInstance(string $className);
 
     /**
      * {@inheritDoc}
      */
-    public function isTransient(string $class) : bool
+    public function isTransient(string $class)
     {
         if (! $this->initialized) {
             $this->initialize();
@@ -358,16 +384,20 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
 
     /**
      * Sets the reflectionService.
+     *
+     * @return void
      */
-    public function setReflectionService(ReflectionService $reflectionService) : void
+    public function setReflectionService(ReflectionService $reflectionService)
     {
         $this->reflectionService = $reflectionService;
     }
 
     /**
      * Gets the reflection service associated with this metadata factory.
+     *
+     * @return ReflectionService
      */
-    public function getReflectionService() : ReflectionService
+    public function getReflectionService()
     {
         if ($this->reflectionService === null) {
             $this->reflectionService = new RuntimeReflectionService();

--- a/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
@@ -13,8 +13,10 @@ interface ClassMetadata
 {
     /**
      * Gets the fully-qualified class name of this persistent class.
+     *
+     * @return string
      */
-    public function getName() : string;
+    public function getName();
 
     /**
      * Gets the mapped identifier field name.
@@ -23,37 +25,49 @@ interface ClassMetadata
      *
      * @return array<int, string>
      */
-    public function getIdentifier() : array;
+    public function getIdentifier();
 
     /**
      * Gets the ReflectionClass instance for this mapped class.
+     *
+     * @return ReflectionClass
      */
-    public function getReflectionClass() : ReflectionClass;
+    public function getReflectionClass();
 
     /**
      * Checks if the given field name is a mapped identifier for this class.
+     *
+     * @return bool
      */
-    public function isIdentifier(string $fieldName) : bool;
+    public function isIdentifier(string $fieldName);
 
     /**
      * Checks if the given field is a mapped property for this class.
+     *
+     * @return bool
      */
-    public function hasField(string $fieldName) : bool;
+    public function hasField(string $fieldName);
 
     /**
      * Checks if the given field is a mapped association for this class.
+     *
+     * @return bool
      */
-    public function hasAssociation(string $fieldName) : bool;
+    public function hasAssociation(string $fieldName);
 
     /**
      * Checks if the given field is a mapped single valued association for this class.
+     *
+     * @return bool
      */
-    public function isSingleValuedAssociation(string $fieldName) : bool;
+    public function isSingleValuedAssociation(string $fieldName);
 
     /**
      * Checks if the given field is a mapped collection valued association for this class.
+     *
+     * @return bool
      */
-    public function isCollectionValuedAssociation(string $fieldName) : bool;
+    public function isCollectionValuedAssociation(string $fieldName);
 
     /**
      * A numerically indexed list of field names of this persistent class.
@@ -62,14 +76,14 @@ interface ClassMetadata
      *
      * @return array<int, string>
      */
-    public function getFieldNames() : array;
+    public function getFieldNames();
 
     /**
      * Returns an array of identifier field names numerically indexed.
      *
      * @return array<int, string>
      */
-    public function getIdentifierFieldNames() : array;
+    public function getIdentifierFieldNames();
 
     /**
      * Returns a numerically indexed list of association names of this persistent class.
@@ -78,30 +92,38 @@ interface ClassMetadata
      *
      * @return array<int, string>
      */
-    public function getAssociationNames() : array;
+    public function getAssociationNames();
 
     /**
      * Returns a type name of this field.
      *
      * This type names can be implementation specific but should at least include the php types:
      * integer, string, boolean, float/double, datetime.
+     *
+     * @return string
      */
-    public function getTypeOfField(string $fieldName) : string;
+    public function getTypeOfField(string $fieldName);
 
     /**
      * Returns the target class name of the given association.
+     *
+     * @return string
      */
-    public function getAssociationTargetClass(string $assocName) : string;
+    public function getAssociationTargetClass(string $assocName);
 
     /**
      * Checks if the association is the inverse side of a bidirectional association.
+     *
+     * @return bool
      */
-    public function isAssociationInverseSide(string $associationName) : bool;
+    public function isAssociationInverseSide(string $assocName);
 
     /**
      * Returns the target field of the owning side of the association.
+     *
+     * @return string
      */
-    public function getAssociationMappedByTargetField(string $associationName) : string;
+    public function getAssociationMappedByTargetField(string $assocName);
 
     /**
      * Returns the identifier of this object as an array with field name as key.
@@ -110,5 +132,5 @@ interface ClassMetadata
      *
      * @return array<string, mixed>
      */
-    public function getIdentifierValues(object $object) : array;
+    public function getIdentifierValues(object $object);
 }

--- a/lib/Doctrine/Persistence/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/ClassMetadataFactory.php
@@ -15,30 +15,36 @@ interface ClassMetadataFactory
      *
      * @return array<int, ClassMetadata> The ClassMetadata instances of all mapped classes.
      */
-    public function getAllMetadata() : array;
+    public function getAllMetadata();
 
     /**
      * Gets the class metadata descriptor for a class.
      *
      * @param string $className The name of the class.
+     *
+     * @return ClassMetadata
      */
-    public function getMetadataFor(string $className) : ClassMetadata;
+    public function getMetadataFor(string $className);
 
     /**
      * Checks whether the factory has the metadata for a class loaded already.
      *
      * @return bool TRUE if the metadata of the class in question is already loaded, FALSE otherwise.
      */
-    public function hasMetadataFor(string $className) : bool;
+    public function hasMetadataFor(string $className);
 
     /**
      * Sets the metadata descriptor for a specific class.
+     *
+     * @return void
      */
-    public function setMetadataFor(string $className, ClassMetadata $class) : void;
+    public function setMetadataFor(string $className, ClassMetadata $class);
 
     /**
      * Returns whether the class with the specified name should have its metadata loaded.
      * This is only the case if it is either mapped directly or as a MappedSuperclass.
+     *
+     * @return bool
      */
-    public function isTransient(string $className) : bool;
+    public function isTransient(string $className);
 }

--- a/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -100,8 +100,10 @@ abstract class AnnotationDriver implements MappingDriver
      * Appends lookup paths to metadata driver.
      *
      * @param array<int, string> $paths
+     *
+     * @return void
      */
-    public function addPaths(array $paths) : void
+    public function addPaths(array $paths)
     {
         $this->paths = array_unique(array_merge($this->paths, $paths));
     }
@@ -111,7 +113,7 @@ abstract class AnnotationDriver implements MappingDriver
      *
      * @return array<int, string>
      */
-    public function getPaths() : array
+    public function getPaths()
     {
         return $this->paths;
     }
@@ -120,8 +122,10 @@ abstract class AnnotationDriver implements MappingDriver
      * Append exclude lookup paths to metadata driver.
      *
      * @param array<int, string> $paths
+     *
+     * @return void
      */
-    public function addExcludePaths(array $paths) : void
+    public function addExcludePaths(array $paths)
     {
         $this->excludePaths = array_unique(array_merge($this->excludePaths, $paths));
     }
@@ -131,23 +135,27 @@ abstract class AnnotationDriver implements MappingDriver
      *
      * @return array<int, string>
      */
-    public function getExcludePaths() : array
+    public function getExcludePaths()
     {
         return $this->excludePaths;
     }
 
     /**
      * Retrieve the current annotation reader
+     *
+     * @return Reader
      */
-    public function getReader() : Reader
+    public function getReader()
     {
         return $this->reader;
     }
 
     /**
      * Gets the file extension used to look for mapping files under.
+     *
+     * @return string
      */
-    public function getFileExtension() : string
+    public function getFileExtension()
     {
         return $this->fileExtension;
     }
@@ -156,8 +164,10 @@ abstract class AnnotationDriver implements MappingDriver
      * Sets the file extension used to look for mapping files under.
      *
      * @param string $fileExtension The file extension to set.
+     *
+     * @return void
      */
-    public function setFileExtension(string $fileExtension) : void
+    public function setFileExtension(string $fileExtension)
     {
         $this->fileExtension = $fileExtension;
     }
@@ -168,8 +178,10 @@ abstract class AnnotationDriver implements MappingDriver
      *
      * A class is non-transient if it is annotated with an annotation
      * from the {@see AnnotationDriver::entityAnnotationClasses}.
+     *
+     * @return bool
      */
-    public function isTransient(string $className) : bool
+    public function isTransient(string $className)
     {
         $classAnnotations = $this->reader->getClassAnnotations(new ReflectionClass($className));
 
@@ -185,7 +197,7 @@ abstract class AnnotationDriver implements MappingDriver
     /**
      * {@inheritDoc}
      */
-    public function getAllClassNames() : array
+    public function getAllClassNames()
     {
         if ($this->classNames !== null) {
             return $this->classNames;

--- a/lib/Doctrine/Persistence/Mapping/Driver/DefaultFileLocator.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/DefaultFileLocator.php
@@ -57,8 +57,10 @@ class DefaultFileLocator implements FileLocator
      * Appends lookup paths to metadata driver.
      *
      * @param array<int, string> $paths
+     *
+     * @return void
      */
-    public function addPaths(array $paths) : void
+    public function addPaths(array $paths)
     {
         $this->paths = array_unique(array_merge($this->paths, $paths));
     }
@@ -68,15 +70,17 @@ class DefaultFileLocator implements FileLocator
      *
      * @return array<int, string>
      */
-    public function getPaths() : array
+    public function getPaths()
     {
         return $this->paths;
     }
 
     /**
      * Gets the file extension used to look for mapping files under.
+     *
+     * @return string|null
      */
-    public function getFileExtension() : ?string
+    public function getFileExtension()
     {
         return $this->fileExtension;
     }
@@ -85,8 +89,10 @@ class DefaultFileLocator implements FileLocator
      * Sets the file extension used to look for mapping files under.
      *
      * @param string|null $fileExtension The file extension to set.
+     *
+     * @return void
      */
-    public function setFileExtension(?string $fileExtension) : void
+    public function setFileExtension(?string $fileExtension)
     {
         $this->fileExtension = $fileExtension;
     }
@@ -94,7 +100,7 @@ class DefaultFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function findMappingFile(string $className) : string
+    public function findMappingFile(string $className)
     {
         $fileName = str_replace('\\', '.', $className) . $this->fileExtension;
 
@@ -111,7 +117,7 @@ class DefaultFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function getAllClassNames(string $globalBasename) : array
+    public function getAllClassNames(string $globalBasename)
     {
         if ($this->paths === []) {
             return [];
@@ -151,7 +157,7 @@ class DefaultFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function fileExists(string $className) : bool
+    public function fileExists(string $className)
     {
         $fileName = str_replace('\\', '.', $className) . $this->fileExtension;
 

--- a/lib/Doctrine/Persistence/Mapping/Driver/FileDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/FileDriver.php
@@ -49,16 +49,20 @@ abstract class FileDriver implements MappingDriver
 
     /**
      * Sets the global basename.
+     *
+     * @return void
      */
-    public function setGlobalBasename(string $file) : void
+    public function setGlobalBasename(string $file)
     {
         $this->globalBasename = $file;
     }
 
     /**
      * Retrieves the global basename.
+     *
+     * @return string|null
      */
-    public function getGlobalBasename() : string
+    public function getGlobalBasename()
     {
         return $this->globalBasename;
     }
@@ -71,7 +75,7 @@ abstract class FileDriver implements MappingDriver
      *
      * @throws MappingException
      */
-    public function getElement(string $className) : ClassMetadata
+    public function getElement(string $className)
     {
         if ($this->classCache === null) {
             $this->initialize();
@@ -98,7 +102,7 @@ abstract class FileDriver implements MappingDriver
     /**
      * {@inheritDoc}
      */
-    public function isTransient(string $className) : bool
+    public function isTransient(string $className)
     {
         if ($this->classCache === null) {
             $this->initialize();
@@ -114,7 +118,7 @@ abstract class FileDriver implements MappingDriver
     /**
      * {@inheritDoc}
      */
-    public function getAllClassNames() : array
+    public function getAllClassNames()
     {
         if ($this->classCache === null) {
             $this->initialize();
@@ -144,7 +148,7 @@ abstract class FileDriver implements MappingDriver
      *
      * @return ClassMetadata[]
      */
-    abstract protected function loadMappingFile(string $file) : array;
+    abstract protected function loadMappingFile(string $file);
 
     /**
      * Initializes the class cache from all the global files.
@@ -154,8 +158,10 @@ abstract class FileDriver implements MappingDriver
      * necessary. This may not be relevant to scenarios where caching of
      * metadata is in place, however hits very hard in scenarios where no
      * caching is used.
+     *
+     * @return void
      */
-    protected function initialize() : void
+    protected function initialize()
     {
         $this->classCache = [];
         if ($this->globalBasename === null) {
@@ -177,16 +183,20 @@ abstract class FileDriver implements MappingDriver
 
     /**
      * Retrieves the locator used to discover mapping files by className.
+     *
+     * @return FileLocator
      */
-    public function getLocator() : FileLocator
+    public function getLocator()
     {
         return $this->locator;
     }
 
     /**
      * Sets the locator used to discover mapping files by className.
+     *
+     * @return void
      */
-    public function setLocator(FileLocator $locator) : void
+    public function setLocator(FileLocator $locator)
     {
         $this->locator = $locator;
     }

--- a/lib/Doctrine/Persistence/Mapping/Driver/FileLocator.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/FileLocator.php
@@ -14,8 +14,10 @@ interface FileLocator
 {
     /**
      * Locates mapping file for the given class name.
+     *
+     * @return string
      */
-    public function findMappingFile(string $className) : string;
+    public function findMappingFile(string $className);
 
     /**
      * Gets all class names that are found with this file locator.
@@ -24,22 +26,26 @@ interface FileLocator
      *
      * @return array<int, string>
      */
-    public function getAllClassNames(string $globalBasename) : array;
+    public function getAllClassNames(string $globalBasename);
 
     /**
      * Checks if a file can be found for this class name.
+     *
+     * @return bool
      */
-    public function fileExists(string $className) : bool;
+    public function fileExists(string $className);
 
     /**
      * Gets all the paths that this file locator looks for mapping files.
      *
      * @return array<int, string>
      */
-    public function getPaths() : array;
+    public function getPaths();
 
     /**
      * Gets the file extension that mapping files are suffixed with.
+     *
+     * @return string|null
      */
-    public function getFileExtension() : ?string;
+    public function getFileExtension();
 }

--- a/lib/Doctrine/Persistence/Mapping/Driver/MappingDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/MappingDriver.php
@@ -13,19 +13,23 @@ interface MappingDriver
 {
     /**
      * Loads the metadata for the specified class into the provided container.
+     *
+     * @return void
      */
-    public function loadMetadataForClass(string $className, ClassMetadata $metadata) : void;
+    public function loadMetadataForClass(string $className, ClassMetadata $metadata);
 
     /**
      * Gets the names of all mapped classes known to this driver.
      *
      * @return array<int, string> The names of all mapped classes known to this driver.
      */
-    public function getAllClassNames() : array;
+    public function getAllClassNames();
 
     /**
      * Returns whether the class with the specified name should have its metadata loaded.
      * This is only the case if it is either mapped as an Entity or a MappedSuperclass.
+     *
+     * @return bool
      */
-    public function isTransient(string $className) : bool;
+    public function isTransient(string $className);
 }

--- a/lib/Doctrine/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -28,24 +28,30 @@ class MappingDriverChain implements MappingDriver
 
     /**
      * Gets the default driver.
+     *
+     * @return MappingDriver|null
      */
-    public function getDefaultDriver() : ?MappingDriver
+    public function getDefaultDriver()
     {
         return $this->defaultDriver;
     }
 
     /**
      * Set the default driver.
+     *
+     * @return void
      */
-    public function setDefaultDriver(MappingDriver $driver) : void
+    public function setDefaultDriver(MappingDriver $driver)
     {
         $this->defaultDriver = $driver;
     }
 
     /**
      * Adds a nested driver.
+     *
+     * @return void
      */
-    public function addDriver(MappingDriver $nestedDriver, string $namespace) : void
+    public function addDriver(MappingDriver $nestedDriver, string $namespace)
     {
         $this->drivers[$namespace] = $nestedDriver;
     }
@@ -55,7 +61,7 @@ class MappingDriverChain implements MappingDriver
      *
      * @return array<string, MappingDriver> $drivers
      */
-    public function getDrivers() : array
+    public function getDrivers()
     {
         return $this->drivers;
     }
@@ -63,7 +69,7 @@ class MappingDriverChain implements MappingDriver
     /**
      * {@inheritDoc}
      */
-    public function loadMetadataForClass(string $className, ClassMetadata $metadata) : void
+    public function loadMetadataForClass(string $className, ClassMetadata $metadata)
     {
         /** @var MappingDriver $driver */
         foreach ($this->drivers as $namespace => $driver) {
@@ -86,7 +92,7 @@ class MappingDriverChain implements MappingDriver
     /**
      * {@inheritDoc}
      */
-    public function getAllClassNames() : array
+    public function getAllClassNames()
     {
         $classNames    = [];
         $driverClasses = [];
@@ -120,7 +126,7 @@ class MappingDriverChain implements MappingDriver
     /**
      * {@inheritDoc}
      */
-    public function isTransient(string $className) : bool
+    public function isTransient(string $className)
     {
         /** @var MappingDriver $driver */
         foreach ($this->drivers as $namespace => $driver) {

--- a/lib/Doctrine/Persistence/Mapping/Driver/PHPDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/PHPDriver.php
@@ -26,7 +26,7 @@ class PHPDriver extends FileDriver
     /**
      * {@inheritDoc}
      */
-    public function loadMetadataForClass(string $className, ClassMetadata $metadata) : void
+    public function loadMetadataForClass(string $className, ClassMetadata $metadata)
     {
         $this->metadata = $metadata;
 
@@ -36,7 +36,7 @@ class PHPDriver extends FileDriver
     /**
      * {@inheritDoc}
      */
-    protected function loadMappingFile(string $file) : array
+    protected function loadMappingFile(string $file)
     {
         $metadata = $this->metadata;
         include $file;

--- a/lib/Doctrine/Persistence/Mapping/Driver/StaticPHPDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/StaticPHPDriver.php
@@ -47,8 +47,10 @@ class StaticPHPDriver implements MappingDriver
 
     /**
      * @param array<int, string> $paths
+     *
+     * @return void
      */
-    public function addPaths(array $paths) : void
+    public function addPaths(array $paths)
     {
         $this->paths = array_unique(array_merge($this->paths, $paths));
     }
@@ -56,7 +58,7 @@ class StaticPHPDriver implements MappingDriver
     /**
      * {@inheritdoc}
      */
-    public function loadMetadataForClass(string $className, ClassMetadata $metadata) : void
+    public function loadMetadataForClass(string $className, ClassMetadata $metadata)
     {
         $className::loadMetadata($metadata);
     }
@@ -66,7 +68,7 @@ class StaticPHPDriver implements MappingDriver
      *
      * @todo Same code exists in AnnotationDriver, should we re-use it somehow or not worry about it?
      */
-    public function getAllClassNames() : array
+    public function getAllClassNames()
     {
         if ($this->classNames !== null) {
             return $this->classNames;
@@ -122,7 +124,7 @@ class StaticPHPDriver implements MappingDriver
     /**
      * {@inheritdoc}
      */
-    public function isTransient(string $className) : bool
+    public function isTransient(string $className)
     {
         return ! method_exists($className, 'loadMetadata');
     }

--- a/lib/Doctrine/Persistence/Mapping/Driver/SymfonyFileLocator.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/SymfonyFileLocator.php
@@ -82,8 +82,10 @@ class SymfonyFileLocator implements FileLocator
      * Adds Namespace Prefixes.
      *
      * @param array<string, string> $prefixes
+     *
+     * @return void
      */
-    public function addNamespacePrefixes(array $prefixes) : void
+    public function addNamespacePrefixes(array $prefixes)
     {
         $this->prefixes = array_merge($this->prefixes, $prefixes);
         $this->paths    = array_merge($this->paths, array_keys($prefixes));
@@ -94,7 +96,7 @@ class SymfonyFileLocator implements FileLocator
      *
      * @return string[]
      */
-    public function getNamespacePrefixes() : array
+    public function getNamespacePrefixes()
     {
         return $this->prefixes;
     }
@@ -102,7 +104,7 @@ class SymfonyFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function getPaths() : array
+    public function getPaths()
     {
         return $this->paths;
     }
@@ -110,7 +112,7 @@ class SymfonyFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function getFileExtension() : ?string
+    public function getFileExtension()
     {
         return $this->fileExtension;
     }
@@ -119,8 +121,10 @@ class SymfonyFileLocator implements FileLocator
      * Sets the file extension used to look for mapping files under.
      *
      * @param string $fileExtension The file extension to set.
+     *
+     * @return void
      */
-    public function setFileExtension(string $fileExtension) : void
+    public function setFileExtension(string $fileExtension)
     {
         $this->fileExtension = $fileExtension;
     }
@@ -128,10 +132,9 @@ class SymfonyFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function fileExists(string $className) : bool
+    public function fileExists(string $className)
     {
         $defaultFileName = str_replace('\\', $this->nsSeparator, $className) . $this->fileExtension;
-
         foreach ($this->paths as $path) {
             if (! isset($this->prefixes[$path])) {
                 // global namespace class
@@ -161,7 +164,7 @@ class SymfonyFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function getAllClassNames(string $globalBasename) : array
+    public function getAllClassNames(?string $globalBasename = null)
     {
         if ($this->paths === []) {
             return [];
@@ -211,7 +214,7 @@ class SymfonyFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function findMappingFile(string $className) : string
+    public function findMappingFile(string $className)
     {
         $defaultFileName = str_replace('\\', $this->nsSeparator, $className) . $this->fileExtension;
         foreach ($this->paths as $path) {

--- a/lib/Doctrine/Persistence/Mapping/MappingException.php
+++ b/lib/Doctrine/Persistence/Mapping/MappingException.php
@@ -15,11 +15,13 @@ class MappingException extends Exception
 {
     /**
      * @param array<int, string> $namespaces
+     *
+     * @return self
      */
     public static function classNotFoundInNamespaces(
         string $className,
         array $namespaces
-    ) : self {
+    ) {
         return new self(sprintf(
             "The class '%s' was not found in the chain configured namespaces %s",
             $className,
@@ -27,15 +29,21 @@ class MappingException extends Exception
         ));
     }
 
-    public static function pathRequired() : self
+    /**
+     * @return self
+     */
+    public static function pathRequired()
     {
         return new self('Specifying the paths to your entities is required ' .
             'in the AnnotationDriver to retrieve all class names.');
     }
 
+    /**
+     * @return self
+     */
     public static function fileMappingDriversRequireConfiguredDirectoryPath(
         ?string $path = null
-    ) : self {
+    ) {
         if ($path !== null) {
             $path = '[' . $path . ']';
         }
@@ -47,7 +55,10 @@ class MappingException extends Exception
         ));
     }
 
-    public static function mappingFileNotFound(string $entityName, string $fileName) : self
+    /**
+     * @return self
+     */
+    public static function mappingFileNotFound(string $entityName, string $fileName)
     {
         return new self(sprintf(
             "No mapping file found named '%s' for class '%s'.",
@@ -56,7 +67,10 @@ class MappingException extends Exception
         ));
     }
 
-    public static function invalidMappingFile(string $entityName, string $fileName) : self
+    /**
+     * @return self
+     */
+    public static function invalidMappingFile(string $entityName, string $fileName)
     {
         return new self(sprintf(
             "Invalid mapping file '%s' for class '%s'.",
@@ -65,7 +79,10 @@ class MappingException extends Exception
         ));
     }
 
-    public static function nonExistingClass(string $className) : self
+    /**
+     * @return self
+     */
+    public static function nonExistingClass(string $className)
     {
         return new self(sprintf("Class '%s' does not exist", $className));
     }

--- a/lib/Doctrine/Persistence/Mapping/ReflectionService.php
+++ b/lib/Doctrine/Persistence/Mapping/ReflectionService.php
@@ -22,27 +22,38 @@ interface ReflectionService
      *
      * @throws MappingException
      */
-    public function getParentClasses(string $class) : array;
+    public function getParentClasses(string $class);
 
     /**
      * Returns the shortname of a class.
+     *
+     * @return string
      */
-    public function getClassShortName(string $class) : string;
+    public function getClassShortName(string $class);
 
-    public function getClassNamespace(string $class) : string;
+    /**
+     * @return string
+     */
+    public function getClassNamespace(string $class);
 
     /**
      * Returns a reflection class instance or null.
+     *
+     * @return ReflectionClass|null
      */
-    public function getClass(string $class) : ?ReflectionClass;
+    public function getClass(string $class);
 
     /**
      * Returns an accessible property (setAccessible(true)) or null.
+     *
+     * @return ReflectionProperty|null
      */
-    public function getAccessibleProperty(string $class, string $property) : ?ReflectionProperty;
+    public function getAccessibleProperty(string $class, string $property);
 
     /**
      * Checks if the class have a public method with the given name.
+     *
+     * @return bool
      */
-    public function hasPublicMethod(string $class, string $method) : bool;
+    public function hasPublicMethod(string $class, string $method);
 }

--- a/lib/Doctrine/Persistence/Mapping/RuntimeReflectionService.php
+++ b/lib/Doctrine/Persistence/Mapping/RuntimeReflectionService.php
@@ -20,7 +20,7 @@ class RuntimeReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getParentClasses(string $class) : array
+    public function getParentClasses(string $class)
     {
         if (! class_exists($class)) {
             throw MappingException::nonExistingClass($class);
@@ -32,7 +32,7 @@ class RuntimeReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getClassShortName(string $class) : string
+    public function getClassShortName(string $class)
     {
         $reflectionClass = new ReflectionClass($class);
 
@@ -42,7 +42,7 @@ class RuntimeReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getClassNamespace(string $class) : string
+    public function getClassNamespace(string $class)
     {
         $reflectionClass = new ReflectionClass($class);
 
@@ -52,7 +52,7 @@ class RuntimeReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getClass(string $class) : ?ReflectionClass
+    public function getClass(string $class)
     {
         return new ReflectionClass($class);
     }
@@ -60,7 +60,7 @@ class RuntimeReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getAccessibleProperty(string $class, string $property) : ?ReflectionProperty
+    public function getAccessibleProperty(string $class, string $property)
     {
         $reflectionProperty = new ReflectionProperty($class, $property);
 
@@ -76,7 +76,7 @@ class RuntimeReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function hasPublicMethod(string $class, string $method) : bool
+    public function hasPublicMethod(string $class, string $method)
     {
         try {
             $reflectionMethod = new ReflectionMethod($class, $method);

--- a/lib/Doctrine/Persistence/Mapping/StaticReflectionService.php
+++ b/lib/Doctrine/Persistence/Mapping/StaticReflectionService.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Persistence\Mapping;
 
-use ReflectionClass;
-use ReflectionProperty;
 use function strpos;
 use function strrev;
 use function strrpos;
@@ -19,7 +17,7 @@ class StaticReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getParentClasses(string $class) : array
+    public function getParentClasses(string $class)
     {
         return [];
     }
@@ -27,7 +25,7 @@ class StaticReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getClassShortName(string $className) : string
+    public function getClassShortName(string $className)
     {
         if (strpos($className, '\\') !== false) {
             /** @var int $pos */
@@ -42,7 +40,7 @@ class StaticReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getClassNamespace(string $className) : string
+    public function getClassNamespace(string $className)
     {
         $namespace = '';
 
@@ -59,7 +57,7 @@ class StaticReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getClass(string $class) : ?ReflectionClass
+    public function getClass(string $class)
     {
         return null;
     }
@@ -67,7 +65,7 @@ class StaticReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getAccessibleProperty(string $class, string $property) : ?ReflectionProperty
+    public function getAccessibleProperty(string $class, string $property)
     {
         return null;
     }
@@ -75,7 +73,7 @@ class StaticReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function hasPublicMethod(string $class, string $method) : bool
+    public function hasPublicMethod(string $class, string $method)
     {
         return true;
     }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,7 +12,9 @@
     <file>lib</file>
     <file>tests</file>
 
-    <rule ref="Doctrine" />
+    <rule ref="Doctrine">
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
+    </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>*/tests/*</exclude-pattern>

--- a/tests/Doctrine/Tests/Persistence/Mapping/FileDriverTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/FileDriverTest.php
@@ -69,7 +69,10 @@ class FileDriverTest extends DoctrineTestCase
 
     public function testGetAllClassNamesGlobalBasename() : void
     {
-        $driver = $this->createTestFileDriver($this->newLocator());
+        $locator = $this->newLocator();
+        $locator->expects(self::any())->method('getAllClassNames')->with('global')->will(self::returnValue(['stdGlobal', 'stdGlobal2']));
+
+        $driver = $this->createTestFileDriver($locator);
         $driver->setGlobalBasename('global');
 
         $classNames = $driver->getAllClassNames();
@@ -118,6 +121,11 @@ class FileDriverTest extends DoctrineTestCase
 
         $driver = $this->createTestFileDriver($locator);
         $driver->setGlobalBasename('global');
+
+        $locator->expects(self::once())
+                ->method('findMappingFile')
+                ->with('stdClass')
+                ->willReturn('');
 
         $driver->getElement('stdClass');
         $classNames = $driver->getAllClassNames();


### PR DESCRIPTION
This partially reverts commit 3e2fad57e1f180e9d6f827c17548171959c1a9a7.

To avoid a hard BC break from 1.x to 2.0, we remove the milestone, as that allows people to install either 1.x or 2.0.

With this, the upgrade process is as follows:
* 1.3.x will deprecate the `Doctrine\Common\Persistence` namespace in favour of the `Doctrine\Persistence` namespace.
* Once the above has been changed, a project can change its version constraint for doctrine/persistence to `^1.3 || ^2.0` without further changes.
* Projects now have to add return type hints to all methods extended from persistence interfaces and classes.
* After a while, we will release version 3.0 which will require return type hints, but will otherwise be compatible with 2.x. This will allow projects to change the version constraint to `^2.0 || ^3.0`.

This ensures a smooth transition where the ecosystem has time to catch up. Otherwise, a single package that upgrades to doctrine/persistence 2.0 could fast-travel a user into dependency hell. **Projects are discouraged from running any single major version constraint** - e.g. running `^2.0` or `^1.0` is discouraged. Dependents should quickly ensure compatibility with 2.0 and update the version constraint as suggested above.