### PR TITLE
Add missing autoload calls

### DIFF
--- a/lib/Doctrine/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Persistence/AbstractManagerRegistry.php
@@ -6,6 +6,7 @@ use InvalidArgumentException;
 use ReflectionClass;
 use function class_exists;
 use function explode;
+use function interface_exists;
 use function sprintf;
 use function strpos;
 
@@ -247,3 +248,4 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
 }
 
 class_exists(\Doctrine\Common\Persistence\AbstractManagerRegistry::class);
+interface_exists(\Doctrine\Common\Persistence\ObjectManager::class);

--- a/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -10,6 +10,7 @@ use function array_reverse;
 use function array_unshift;
 use function class_exists;
 use function explode;
+use function interface_exists;
 use function strpos;
 use function strrpos;
 use function substr;
@@ -415,3 +416,5 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
 }
 
 class_exists(\Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory::class);
+interface_exists(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+interface_exists(\Doctrine\Common\Persistence\Mapping\ReflectionService::class);

--- a/lib/Doctrine/Persistence/Mapping/Driver/FileDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/FileDriver.php
@@ -8,6 +8,7 @@ use function array_keys;
 use function array_merge;
 use function array_unique;
 use function class_exists;
+use function interface_exists;
 use function is_file;
 use function str_replace;
 
@@ -195,3 +196,4 @@ abstract class FileDriver implements MappingDriver
 }
 
 class_exists(\Doctrine\Common\Persistence\Mapping\Driver\FileDriver::class);
+interface_exists(\Doctrine\Common\Persistence\Mapping\Driver\FileLocator::class);

--- a/lib/Doctrine/Persistence/Mapping/Driver/MappingDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/MappingDriver.php
@@ -37,4 +37,5 @@ interface MappingDriver
     public function isTransient($className);
 }
 
+interface_exists(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
 interface_exists(\Doctrine\Common\Persistence\Mapping\Driver\MappingDriver::class);

--- a/lib/Doctrine/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -6,6 +6,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\MappingException;
 use function array_keys;
 use function class_exists;
+use function interface_exists;
 use function spl_object_hash;
 use function strpos;
 
@@ -145,3 +146,4 @@ class MappingDriverChain implements MappingDriver
 }
 
 class_exists(\Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain::class);
+interface_exists(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);

--- a/lib/Doctrine/Persistence/Mapping/Driver/PHPDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/PHPDriver.php
@@ -4,6 +4,7 @@ namespace Doctrine\Persistence\Mapping\Driver;
 
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use function class_exists;
+use function interface_exists;
 
 /**
  * The PHPDriver includes php files which just populate ClassMetadataInfo
@@ -45,3 +46,4 @@ class PHPDriver extends FileDriver
 }
 
 class_exists(\Doctrine\Common\Persistence\Mapping\Driver\PHPDriver::class);
+interface_exists(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);

--- a/lib/Doctrine/Persistence/Mapping/Driver/StaticPHPDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/StaticPHPDriver.php
@@ -12,6 +12,7 @@ use function array_unique;
 use function class_exists;
 use function get_declared_classes;
 use function in_array;
+use function interface_exists;
 use function is_dir;
 use function method_exists;
 use function realpath;
@@ -130,3 +131,4 @@ class StaticPHPDriver implements MappingDriver
 }
 
 class_exists(\Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver::class);
+interface_exists(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);

--- a/lib/Doctrine/Persistence/NotifyPropertyChanged.php
+++ b/lib/Doctrine/Persistence/NotifyPropertyChanged.php
@@ -22,3 +22,4 @@ interface NotifyPropertyChanged
 }
 
 interface_exists(\Doctrine\Common\NotifyPropertyChanged::class);
+interface_exists(\Doctrine\Common\PropertyChangedListener::class);

--- a/lib/Doctrine/Persistence/ObjectManagerAware.php
+++ b/lib/Doctrine/Persistence/ObjectManagerAware.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Persistence;
 
 use Doctrine\Persistence\Mapping\ClassMetadata;
+use function interface_exists;
 
 /**
  * Makes a Persistent Objects aware of its own object-manager.
@@ -27,3 +28,6 @@ interface ObjectManagerAware
      */
     public function injectObjectManager(ObjectManager $objectManager, ClassMetadata $classMetadata);
 }
+
+interface_exists(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+interface_exists(\Doctrine\Common\Persistence\ObjectManager::class);


### PR DESCRIPTION
Types extending these but having the old type declarations might not be
considered compatible unless we autoload the type declarations.

Fixes #78 

# How can I test this?

```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/doctrine-persistence
composer require doctrine/persistence "dev-load-classes-in-type-declarations as 1.3.0"
```