### PR TITLE
Temporarily remove deprecations about ns move

### DIFF
--- a/lib/Doctrine/Common/NotifyPropertyChanged.php
+++ b/lib/Doctrine/Common/NotifyPropertyChanged.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function interface_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! interface_exists(\Doctrine\Persistence\NotifyPropertyChanged::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\NotifyPropertyChanged class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\NotifyPropertyChanged instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\NotifyPropertyChanged::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\NotifyPropertyChanged
-     */
     interface NotifyPropertyChanged extends \Doctrine\Persistence\NotifyPropertyChanged
     {
     }

--- a/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\AbstractManagerRegistry::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\AbstractManagerRegistry class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\AbstractManagerRegistry instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\AbstractManagerRegistry::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\AbstractManagerRegistry
-     */
     abstract class AbstractManagerRegistry extends \Doctrine\Persistence\AbstractManagerRegistry
     {
     }

--- a/lib/Doctrine/Common/Persistence/ConnectionRegistry.php
+++ b/lib/Doctrine/Common/Persistence/ConnectionRegistry.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function interface_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! interface_exists(\Doctrine\Persistence\ConnectionRegistry::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\ConnectionRegistry class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\ConnectionRegistry instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\ConnectionRegistry::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\ConnectionRegistry
-     */
     interface ConnectionRegistry extends \Doctrine\Persistence\ConnectionRegistry
     {
     }

--- a/lib/Doctrine/Common/Persistence/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/LifecycleEventArgs.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Event;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Event\LifecycleEventArgs::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\LifecycleEventArgs class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Event\LifecycleEventArgs instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Event\LifecycleEventArgs::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Event\LifecycleEventArgs
-     */
     class LifecycleEventArgs extends \Doctrine\Persistence\Event\LifecycleEventArgs
     {
     }

--- a/lib/Doctrine/Common/Persistence/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/LoadClassMetadataEventArgs.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Event;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Event\LoadClassMetadataEventArgs::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\LoadClassMetadataEventArgs class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Event\LoadClassMetadataEventArgs instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Event\LoadClassMetadataEventArgs::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Event\LoadClassMetadataEventArgs
-     */
     class LoadClassMetadataEventArgs extends \Doctrine\Persistence\Event\LoadClassMetadataEventArgs
     {
     }

--- a/lib/Doctrine/Common/Persistence/Event/ManagerEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/ManagerEventArgs.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Event;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Event\ManagerEventArgs::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\ManagerEventArgs class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Event\ManagerEventArgs instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Event\ManagerEventArgs::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Event\ManagerEventArgs
-     */
     class ManagerEventArgs extends \Doctrine\Persistence\Event\ManagerEventArgs
     {
     }

--- a/lib/Doctrine/Common/Persistence/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/OnClearEventArgs.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Event;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Event\OnClearEventArgs::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\OnClearEventArgs class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Event\OnClearEventArgs instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Event\OnClearEventArgs::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Event\OnClearEventArgs
-     */
     class OnClearEventArgs extends \Doctrine\Persistence\Event\OnClearEventArgs
     {
     }

--- a/lib/Doctrine/Common/Persistence/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/PreUpdateEventArgs.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Event;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Event\PreUpdateEventArgs::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\PreUpdateEventArgs class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Event\PreUpdateEventArgs instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Event\PreUpdateEventArgs::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Event\PreUpdateEventArgs
-     */
     class PreUpdateEventArgs extends \Doctrine\Persistence\Event\PreUpdateEventArgs
     {
     }

--- a/lib/Doctrine/Common/Persistence/ManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/ManagerRegistry.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function interface_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! interface_exists(\Doctrine\Persistence\ManagerRegistry::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\ManagerRegistry class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\ManagerRegistry instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\ManagerRegistry::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\ManagerRegistry
-     */
     interface ManagerRegistry extends \Doctrine\Persistence\ManagerRegistry
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\AbstractClassMetadataFactory class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\AbstractClassMetadataFactory
-     */
     class AbstractClassMetadataFactory extends \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ClassMetadata.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function interface_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! interface_exists(\Doctrine\Persistence\Mapping\ClassMetadata::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\ClassMetadata class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\ClassMetadata instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\ClassMetadata::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\ClassMetadata
-     */
     interface ClassMetadata extends \Doctrine\Persistence\Mapping\ClassMetadata
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ClassMetadataFactory.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function interface_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! interface_exists(\Doctrine\Persistence\Mapping\ClassMetadataFactory::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\ClassMetadataFactory class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\ClassMetadataFactory instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\ClassMetadataFactory::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\ClassMetadataFactory
-     */
     interface ClassMetadataFactory extends \Doctrine\Persistence\Mapping\ClassMetadataFactory
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Mapping\Driver\AnnotationDriver::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\AnnotationDriver class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\Driver\AnnotationDriver instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\Driver\AnnotationDriver::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\Driver\AnnotationDriver
-     */
     abstract class AnnotationDriver extends \Doctrine\Persistence\Mapping\Driver\AnnotationDriver
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Mapping\Driver\DefaultFileLocator::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\DefaultFileLocator class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\Driver\DefaultFileLocator instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\Driver\DefaultFileLocator::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\Driver\DefaultFileLocator
-     */
     class DefaultFileLocator extends \Doctrine\Persistence\Mapping\Driver\DefaultFileLocator
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Mapping\Driver\FileDriver::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\FileDriver class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\Driver\FileDriver instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\Driver\FileDriver::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\Driver\FileDriver
-     */
     abstract class FileDriver extends \Doctrine\Persistence\Mapping\Driver\FileDriver
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/FileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/FileLocator.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function interface_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! interface_exists(\Doctrine\Persistence\Mapping\Driver\FileLocator::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\FileLocator class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\Driver\FileLocator instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\Driver\FileLocator::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\Driver\FileLocator
-     */
     interface FileLocator extends \Doctrine\Persistence\Mapping\Driver\FileLocator
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriver.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function interface_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! interface_exists(\Doctrine\Persistence\Mapping\Driver\MappingDriver::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\MappingDriver class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\Driver\MappingDriver instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\Driver\MappingDriver::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\Driver\MappingDriver
-     */
     interface MappingDriver extends \Doctrine\Persistence\Mapping\Driver\MappingDriver
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Mapping\Driver\MappingDriverChain::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\MappingDriverChain class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\Driver\MappingDriverChain instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\Driver\MappingDriverChain::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\Driver\MappingDriverChain
-     */
     class MappingDriverChain extends \Doctrine\Persistence\Mapping\Driver\MappingDriverChain
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/PHPDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/PHPDriver.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Mapping\Driver\PHPDriver::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\PHPDriver class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\Driver\PHPDriver instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\Driver\PHPDriver::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\Driver\PHPDriver
-     */
     class PHPDriver extends \Doctrine\Persistence\Mapping\Driver\PHPDriver
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/StaticPHPDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/StaticPHPDriver.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Mapping\Driver\StaticPHPDriver::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\Driver\StaticPHPDriver class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\Driver\StaticPHPDriver instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\Driver\StaticPHPDriver::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\Driver\StaticPHPDriver
-     */
     class StaticPHPDriver extends \Doctrine\Persistence\Mapping\Driver\StaticPHPDriver
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/SymfonyFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/SymfonyFileLocator.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\SymfonyFileLocator class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator
-     */
     class SymfonyFileLocator extends \Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Mapping\MappingException::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\MappingException class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\MappingException instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\MappingException::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\MappingException
-     */
     class MappingException extends \Doctrine\Persistence\Mapping\MappingException
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/ReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ReflectionService.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function interface_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! interface_exists(\Doctrine\Persistence\Mapping\ReflectionService::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\ReflectionService class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\ReflectionService instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\ReflectionService::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\ReflectionService
-     */
     interface ReflectionService extends \Doctrine\Persistence\Mapping\ReflectionService
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Mapping\RuntimeReflectionService::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\RuntimeReflectionService class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\RuntimeReflectionService instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\RuntimeReflectionService::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\RuntimeReflectionService
-     */
     class RuntimeReflectionService extends \Doctrine\Persistence\Mapping\RuntimeReflectionService
     {
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\Mapping\StaticReflectionService::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\StaticReflectionService class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Mapping\StaticReflectionService instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Mapping\StaticReflectionService::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Mapping\StaticReflectionService
-     */
     class StaticReflectionService extends \Doctrine\Persistence\Mapping\StaticReflectionService
     {
     }

--- a/lib/Doctrine/Common/Persistence/ObjectManager.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManager.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function interface_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! interface_exists(\Doctrine\Persistence\ObjectManager::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\ObjectManager class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\ObjectManager instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\ObjectManager::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\ObjectManager
-     */
     interface ObjectManager extends \Doctrine\Persistence\ObjectManager
     {
     }

--- a/lib/Doctrine/Common/Persistence/ObjectManagerAware.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManagerAware.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function interface_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! interface_exists(\Doctrine\Persistence\ObjectManagerAware::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\ObjectManagerAware class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\ObjectManagerAware instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\ObjectManagerAware::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\ObjectManagerAware
-     */
     interface ObjectManagerAware extends \Doctrine\Persistence\ObjectManagerAware
     {
     }

--- a/lib/Doctrine/Common/Persistence/ObjectManagerDecorator.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManagerDecorator.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function class_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! class_exists(\Doctrine\Persistence\ObjectManagerDecorator::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\ObjectManagerDecorator class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\ObjectManagerDecorator instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\ObjectManagerDecorator::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\ObjectManagerDecorator
-     */
     abstract class ObjectManagerDecorator extends \Doctrine\Persistence\ObjectManagerDecorator
     {
     }

--- a/lib/Doctrine/Common/Persistence/ObjectRepository.php
+++ b/lib/Doctrine/Common/Persistence/ObjectRepository.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function interface_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! interface_exists(\Doctrine\Persistence\ObjectRepository::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\ObjectRepository class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\ObjectRepository instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\ObjectRepository::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\ObjectRepository
-     */
     interface ObjectRepository extends \Doctrine\Persistence\ObjectRepository
     {
     }

--- a/lib/Doctrine/Common/Persistence/Proxy.php
+++ b/lib/Doctrine/Common/Persistence/Proxy.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common\Persistence;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function interface_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! interface_exists(\Doctrine\Persistence\Proxy::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\Proxy class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\Proxy instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\Proxy::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\Proxy
-     */
     interface Proxy extends \Doctrine\Persistence\Proxy
     {
     }

--- a/lib/Doctrine/Common/PropertyChangedListener.php
+++ b/lib/Doctrine/Common/PropertyChangedListener.php
@@ -2,19 +2,7 @@
 
 namespace Doctrine\Common;
 
-use const E_USER_DEPRECATED;
 use function class_alias;
-use function interface_exists;
-use function sprintf;
-use function trigger_error;
-
-if (! interface_exists(\Doctrine\Persistence\PropertyChangedListener::class, false)) {
-    @trigger_error(sprintf(
-        'The %s\PropertyChangedListener class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0.'
-        . ' Use \Doctrine\Persistence\PropertyChangedListener instead.',
-        __NAMESPACE__
-    ), E_USER_DEPRECATED);
-}
 
 class_alias(
     \Doctrine\Persistence\PropertyChangedListener::class,
@@ -22,9 +10,6 @@ class_alias(
 );
 
 if (false) {
-    /**
-     * @deprecated 1.3 Use Doctrine\Persistence\PropertyChangedListener
-     */
     interface PropertyChangedListener extends \Doctrine\Persistence\PropertyChangedListener
     {
     }


### PR DESCRIPTION
We want to give ourselves time to address them in the other packages we
own and that consume this library.
Not doing so generates a lot of support from people asking how they can
fix the deprecations in their application, which they cannot. This
commit should be reverted in a following release, when at least all of
our packages have made the move.