### PR TITLE
Added support for TypedNoDefaultReflectionProperty class to RuntimeReflectionService

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "doctrine/cache": "^1.0",
         "doctrine/collections": "^1.0",
         "doctrine/event-manager": "^1.0",
-        "doctrine/reflection": "^1.0"
+        "doctrine/reflection": "^1.1"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.11",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c54b3ae229d89a221e499f1c73c0837",
+    "content-hash": "e389212c857986d6c1bb5d86626676c7",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -349,16 +349,16 @@
         },
         {
             "name": "doctrine/reflection",
-            "version": "v1.0.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/reflection.git",
-                "reference": "02538d3f95e88eb397a5f86274deb2c6175c2ab6"
+                "reference": "bc420ead87fdfe08c03ecc3549db603a45b06d4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/reflection/zipball/02538d3f95e88eb397a5f86274deb2c6175c2ab6",
-                "reference": "02538d3f95e88eb397a5f86274deb2c6175c2ab6",
+                "url": "https://api.github.com/repos/doctrine/reflection/zipball/bc420ead87fdfe08c03ecc3549db603a45b06d4c",
+                "reference": "bc420ead87fdfe08c03ecc3549db603a45b06d4c",
                 "shasum": ""
             },
             "require": {
@@ -366,13 +366,15 @@
                 "ext-tokenizer": "*",
                 "php": "^7.1"
             },
+            "conflict": {
+                "doctrine/common": "<2.9"
+            },
             "require-dev": {
-                "doctrine/coding-standard": "^4.0",
-                "doctrine/common": "^2.8",
-                "phpstan/phpstan": "^0.9.2",
-                "phpstan/phpstan-phpunit": "^0.9.4",
-                "phpunit/phpunit": "^7.0",
-                "squizlabs/php_codesniffer": "^3.0"
+                "doctrine/coding-standard": "^5.0",
+                "doctrine/common": "^2.10",
+                "phpstan/phpstan": "^0.11.0",
+                "phpstan/phpstan-phpunit": "^0.11.0",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -391,16 +393,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -415,12 +417,13 @@
                     "email": "ocramius@gmail.com"
                 }
             ],
-            "description": "Doctrine Reflection component",
+            "description": "The Doctrine Reflection project is a simple library used by the various Doctrine projects which adds some additional functionality on top of the reflection functionality that comes with PHP. It allows you to get the reflection information about classes, methods and properties statically.",
             "homepage": "https://www.doctrine-project.org/projects/reflection.html",
             "keywords": [
-                "reflection"
+                "reflection",
+                "static"
             ],
-            "time": "2018-06-14T14:45:07+00:00"
+            "time": "2020-01-08T19:53:19+00:00"
         }
     ],
     "packages-dev": [

--- a/lib/Doctrine/Persistence/Mapping/RuntimeReflectionService.php
+++ b/lib/Doctrine/Persistence/Mapping/RuntimeReflectionService.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\Persistence\Mapping;
 
 use Doctrine\Common\Reflection\RuntimePublicReflectionProperty;
+use Doctrine\Common\Reflection\TypedNoDefaultReflectionProperty;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionMethod;
 use ReflectionProperty;
+use function array_key_exists;
 use function class_exists;
 use function class_parents;
 
@@ -64,7 +66,9 @@ class RuntimeReflectionService implements ReflectionService
     {
         $reflectionProperty = new ReflectionProperty($class, $property);
 
-        if ($reflectionProperty->isPublic()) {
+        if (! array_key_exists($property, $this->getClass($class)->getDefaultProperties())) {
+            $reflectionProperty = new TypedNoDefaultReflectionProperty($class, $property);
+        } elseif ($reflectionProperty->isPublic()) {
             $reflectionProperty = new RuntimePublicReflectionProperty($class, $property);
         }
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,8 @@
 >
     <testsuites>
         <testsuite name="Doctrine Persistence Test Suite">
-            <directory>./tests/Doctrine/</directory>
+            <directory>./tests/Doctrine/Tests</directory>
+            <directory phpVersion="7.4" phpVersionOperator=">=">./tests/Doctrine/Tests_PHP74</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/Doctrine/Tests_PHP74/Persistence/Mapping/RuntimeReflectionServiceTest.php
+++ b/tests/Doctrine/Tests_PHP74/Persistence/Mapping/RuntimeReflectionServiceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests_PHP74\Persistence\Mapping;
+
+use Doctrine\Common\Reflection\TypedNoDefaultReflectionProperty;
+use Doctrine\Persistence\Mapping\RuntimeReflectionService;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+/**
+ * @group DCOM-93
+ */
+class RuntimeReflectionServiceTest extends TestCase
+{
+    /** @var RuntimeReflectionService */
+    private $reflectionService;
+
+    /** @var mixed */
+    private string $typedNoDefaultProperty;
+
+    /** @var mixed */
+    private string $typedDefaultProperty = '';
+
+    protected function setUp() : void
+    {
+        $this->reflectionService = new RuntimeReflectionService();
+    }
+
+    public function testGetTypedNoDefaultReflectionProperty() : void
+    {
+        $reflProp = $this->reflectionService->getAccessibleProperty(self::class, 'typedNoDefaultProperty');
+        self::assertInstanceOf(TypedNoDefaultReflectionProperty::class, $reflProp);
+    }
+
+    public function testGetTypedDefaultReflectionProperty() : void
+    {
+        $reflProp = $this->reflectionService->getAccessibleProperty(self::class, 'typedDefaultProperty');
+        self::assertInstanceOf(ReflectionProperty::class, $reflProp);
+        self::assertNotInstanceOf(TypedNoDefaultReflectionProperty::class, $reflProp);
+    }
+}


### PR DESCRIPTION
Implementation for issue #89 
See discussion in doctrine/orm#7857

As suggested by @beberlei, the `Doctrine\Common\Reflection\TypedNoDefaultReflectionProperty` class was introduced and the `Doctrine\Persistence\Mapping\RuntimeReflectionService::getAccessibleProperty` returns an instance of this class if the property is typed and has no default value.