### PR TITLE
Trigger autoload for deprecated type

### DIFF
--- a/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -255,4 +255,4 @@ abstract class AnnotationDriver implements MappingDriver
     }
 }
 
-class_exists(\Doctrine\Persistence\Mapping\Driver\AnnotationDriver::class);
+class_exists(\Doctrine\Common\Persistence\Mapping\Driver\AnnotationDriver::class);

--- a/lib/Doctrine/Persistence/Mapping/ReflectionService.php
+++ b/lib/Doctrine/Persistence/Mapping/ReflectionService.php
@@ -71,4 +71,4 @@ interface ReflectionService
     public function hasPublicMethod($class, $method);
 }
 
-interface_exists(\Doctrine\Persistence\Mapping\ReflectionService::class);
+interface_exists(\Doctrine\Common\Persistence\Mapping\ReflectionService::class);


### PR DESCRIPTION
That is what was intended originally, but instead, no autoload was triggered
at all since we just created the type that is referenced here.

Closes #91