### PR TITLE
Add typed no default reflection property class usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 cache:
   directories:
@@ -23,9 +23,6 @@ script:
   - ./vendor/bin/phpunit
 
 jobs:
-  allow_failures:
-    - php: 7.4snapshot
-
   include:
     - stage: Test
       env: DEPENDENCIES=low
@@ -50,6 +47,7 @@ jobs:
       script: ./vendor/bin/phpcs
 
     - stage: Code Quality
+      php: 7.4
       env: STATIC_ANALYSIS
       install: travis_retry composer install --prefer-dist
       script: vendor/bin/phpstan analyze

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "doctrine/cache": "^1.0",
         "doctrine/collections": "^1.0",
         "doctrine/event-manager": "^1.0",
-        "doctrine/reflection": "^1.0"
+        "doctrine/reflection": "^1.1"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.11",
@@ -43,7 +43,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Doctrine\\Tests\\": "tests/Doctrine/Tests"
+            "Doctrine\\Tests\\": "tests/Doctrine/Tests",
+            "Doctrine\\Tests_PHP74\\": "tests/Doctrine/Tests_PHP74"
         }
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cdc5901fd6bb83a65afddc4be366d454",
+    "content-hash": "5cb2477373746c5e1f76986cf3ad36dd",
     "packages": [
         {
             "name": "doctrine/annotations",
-            "version": "v1.6.0",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5"
+                "reference": "904dca4eb10715b92569fbcd79e201d5c349b6bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
-                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/904dca4eb10715b92569fbcd79e201d5c349b6bc",
+                "reference": "904dca4eb10715b92569fbcd79e201d5c349b6bc",
                 "shasum": ""
             },
             "require": {
@@ -26,12 +26,12 @@
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^7.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -45,16 +45,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -72,7 +72,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2017-12-06T07:11:42+00:00"
+            "time": "2019-10-01T18:55:10+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -345,16 +345,16 @@
         },
         {
             "name": "doctrine/reflection",
-            "version": "v1.0.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/reflection.git",
-                "reference": "02538d3f95e88eb397a5f86274deb2c6175c2ab6"
+                "reference": "bc420ead87fdfe08c03ecc3549db603a45b06d4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/reflection/zipball/02538d3f95e88eb397a5f86274deb2c6175c2ab6",
-                "reference": "02538d3f95e88eb397a5f86274deb2c6175c2ab6",
+                "url": "https://api.github.com/repos/doctrine/reflection/zipball/bc420ead87fdfe08c03ecc3549db603a45b06d4c",
+                "reference": "bc420ead87fdfe08c03ecc3549db603a45b06d4c",
                 "shasum": ""
             },
             "require": {
@@ -362,13 +362,15 @@
                 "ext-tokenizer": "*",
                 "php": "^7.1"
             },
+            "conflict": {
+                "doctrine/common": "<2.9"
+            },
             "require-dev": {
-                "doctrine/coding-standard": "^4.0",
-                "doctrine/common": "^2.8",
-                "phpstan/phpstan": "^0.9.2",
-                "phpstan/phpstan-phpunit": "^0.9.4",
-                "phpunit/phpunit": "^7.0",
-                "squizlabs/php_codesniffer": "^3.0"
+                "doctrine/coding-standard": "^5.0",
+                "doctrine/common": "^2.10",
+                "phpstan/phpstan": "^0.11.0",
+                "phpstan/phpstan-phpunit": "^0.11.0",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -387,16 +389,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -411,12 +413,13 @@
                     "email": "ocramius@gmail.com"
                 }
             ],
-            "description": "Doctrine Reflection component",
+            "description": "The Doctrine Reflection project is a simple library used by the various Doctrine projects which adds some additional functionality on top of the reflection functionality that comes with PHP. It allows you to get the reflection information about classes, methods and properties statically.",
             "homepage": "https://www.doctrine-project.org/projects/reflection.html",
             "keywords": [
-                "reflection"
+                "reflection",
+                "static"
             ],
-            "time": "2018-06-14T14:45:07+00:00"
+            "time": "2020-01-08T19:53:19+00:00"
         }
     ],
     "packages-dev": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,8 @@
 >
     <testsuites>
         <testsuite name="Doctrine Persistence Test Suite">
-            <directory>./tests/Doctrine/</directory>
+            <directory>./tests/Doctrine/Tests</directory>
+            <directory phpVersion="7.4" phpVersionOperator=">=">./tests/Doctrine/Tests_PHP74</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/Doctrine/Tests_PHP74/Persistence/Mapping/RuntimeReflectionServiceTest.php
+++ b/tests/Doctrine/Tests_PHP74/Persistence/Mapping/RuntimeReflectionServiceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests_PHP74\Persistence\Mapping;
+
+use Doctrine\Common\Reflection\RuntimePublicReflectionProperty;
+use Doctrine\Common\Reflection\TypedNoDefaultReflectionProperty;
+use Doctrine\Persistence\Mapping\RuntimeReflectionService;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+/**
+ * @group DCOM-93
+ */
+class RuntimeReflectionServiceTest extends TestCase
+{
+    /** @var RuntimeReflectionService */
+    private $reflectionService;
+
+    /** @var string */
+    private string $typedNoDefaultProperty;
+    /** @var string */
+    private string $typedDefaultProperty = '';
+
+    /** @var string */
+    public string $typedNoDefaultPublicProperty;
+
+    protected function setUp() : void
+    {
+        $this->reflectionService = new RuntimeReflectionService();
+    }
+
+    public function testGetTypedNoDefaultReflectionProperty() : void
+    {
+        $reflProp = $this->reflectionService->getAccessibleProperty(self::class, 'typedNoDefaultProperty');
+        self::assertInstanceOf(TypedNoDefaultReflectionProperty::class, $reflProp);
+    }
+
+    public function testGetTypedDefaultReflectionProperty() : void
+    {
+        $reflProp = $this->reflectionService->getAccessibleProperty(self::class, 'typedDefaultProperty');
+        self::assertInstanceOf(ReflectionProperty::class, $reflProp);
+        self::assertNotInstanceOf(TypedNoDefaultReflectionProperty::class, $reflProp);
+    }
+
+    public function testGetTypedPublicNoDefaultPropertyWorksWithGetValue() : void
+    {
+        $reflProp = $this->reflectionService->getAccessibleProperty(self::class, 'typedNoDefaultPublicProperty');
+        self::assertInstanceOf(RuntimePublicReflectionProperty::class, $reflProp);
+        self::assertNull($reflProp->getValue($this));
+    }
+}


### PR DESCRIPTION
Supersedes #90 

This adds a check for PHP 7.4 so that we don't incur the overhead of `getDefaultProperties` every time.

It also changes the order of the reflection property creations, because RuntimePublicReflectionProperty already works with typed no default properties, and its the more specialized version that is necessary to be used to don't break lazy loading on typed properties.

@sspat Can you check?

Fixes #89 