### PR TITLE
Remove Scrutinizer badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Doctrine Persistence
 
 [![Build Status](https://travis-ci.org/doctrine/persistence.svg)](https://travis-ci.org/doctrine/persistence)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/doctrine/persistence/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/doctrine/persistence/?branch=master)
 [![Code Coverage](https://codecov.io/gh/doctrine/persistence/branch/master/graph/badge.svg)](https://codecov.io/gh/doctrine/persistence/branch/master)
 
 The Doctrine Persistence project is a library that provides common abstractions for object mapper persistence.


### PR DESCRIPTION
We no longer use Scrutinizer. I should have removed it in #115 :facepalm: 