### PR TITLE
Bail out early on anonymous class 

### DIFF
--- a/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -154,6 +154,10 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      */
     public function getMetadataFor($className)
     {
+        if (strpos($className, '@anonymous') !== false) {
+            throw MappingException::anonymousClass($className);
+        }
+
         if (isset($this->loadedMetadata[$className])) {
             return $this->loadedMetadata[$className];
         }

--- a/lib/Doctrine/Persistence/Mapping/MappingException.php
+++ b/lib/Doctrine/Persistence/Mapping/MappingException.php
@@ -93,6 +93,11 @@ class MappingException extends Exception
     {
         return new self(sprintf("Class '%s' does not exist", $className));
     }
+
+    public static function anonymousClass(string $className) : self
+    {
+        return new self(sprintf("The class '%s' is anonymous.", $className));
+    }
 }
 
 class_exists(\Doctrine\Common\Persistence\Mapping\MappingException::class);

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -10,6 +10,7 @@ use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Tests\DoctrineTestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use stdClass;
+use function get_class;
 
 /**
  * @covers \Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory
@@ -32,6 +33,17 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $cache = new ArrayCache();
         $this->cmf->setCacheDriver($cache);
         self::assertSame($cache, $this->cmf->getCacheDriver());
+    }
+
+    public function testGetMetadataForAnonymousClass() : void
+    {
+        $object = new class () extends stdClass {
+        };
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('anonymous');
+
+        $this->cmf->getMetadataFor(get_class($object));
     }
 
     public function testGetMetadataFor()


### PR DESCRIPTION
A colon is used later in this class:

https://github.com/doctrine/persistence/blob/ebb6c322b4b438e4156523dafca1aedb1342353a/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php#L160-L166

That's in order to handle aliased namespaces in
which case the argument passed to `getMetadataFor` looks like this:

`alias:ModelClassName`

On Windows, this causes an issue because the string representation of
anonymous classes can contain the driver letter (typically `C:\`), which
includes a colon.

For instance, for
`class@anonymous\x00E:\dev\www\skeleton\src\AppBundle\Controller\DefaultController.php000001982329027F`,
`class@anonymous\x00E` will wrongly be interpreted as a namespace alias
and you will get the following message:

> Unknown Entity namespace alias 'class@anonymousE'.

Fixes #24