### PR TITLE
Fixes #97 - Preloading issues

### DIFF
--- a/lib/Doctrine/Common/NotifyPropertyChanged.php
+++ b/lib/Doctrine/Common/NotifyPropertyChanged.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\NotifyPropertyChanged::class,
-    __NAMESPACE__ . '\NotifyPropertyChanged'
-);
+if (!class_exists(__NAMESPACE__ . '\NotifyPropertyChanged')) {
+    class_alias(
+        \Doctrine\Persistence\NotifyPropertyChanged::class,
+        __NAMESPACE__ . '\NotifyPropertyChanged'
+    );
+}
 
 if (false) {
     interface NotifyPropertyChanged extends \Doctrine\Persistence\NotifyPropertyChanged

--- a/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\AbstractManagerRegistry::class,
-    __NAMESPACE__ . '\AbstractManagerRegistry'
-);
+if (!class_exists(__NAMESPACE__ . '\AbstractManagerRegistry')) {
+    class_alias(
+        \Doctrine\Persistence\AbstractManagerRegistry::class,
+        __NAMESPACE__ . '\AbstractManagerRegistry'
+    );
+}
 
 if (false) {
     abstract class AbstractManagerRegistry extends \Doctrine\Persistence\AbstractManagerRegistry

--- a/lib/Doctrine/Common/Persistence/ConnectionRegistry.php
+++ b/lib/Doctrine/Common/Persistence/ConnectionRegistry.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\ConnectionRegistry::class,
-    __NAMESPACE__ . '\ConnectionRegistry'
-);
+if (!class_exists(__NAMESPACE__ . '\ConnectionRegistry')) {
+    class_alias(
+        \Doctrine\Persistence\ConnectionRegistry::class,
+        __NAMESPACE__ . '\ConnectionRegistry'
+    );
+}
 
 if (false) {
     interface ConnectionRegistry extends \Doctrine\Persistence\ConnectionRegistry

--- a/lib/Doctrine/Common/Persistence/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/LifecycleEventArgs.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Event;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Event\LifecycleEventArgs::class,
-    __NAMESPACE__ . '\LifecycleEventArgs'
-);
+if (!class_exists(__NAMESPACE__ . '\LifecycleEventArgs')) {
+    class_alias(
+        \Doctrine\Persistence\Event\LifecycleEventArgs::class,
+        __NAMESPACE__ . '\LifecycleEventArgs'
+    );
+}
 
 if (false) {
     class LifecycleEventArgs extends \Doctrine\Persistence\Event\LifecycleEventArgs

--- a/lib/Doctrine/Common/Persistence/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/LoadClassMetadataEventArgs.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Event;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Event\LoadClassMetadataEventArgs::class,
-    __NAMESPACE__ . '\LoadClassMetadataEventArgs'
-);
+if (!class_exists(__NAMESPACE__ . '\LoadClassMetadataEventArgs')) {
+    class_alias(
+        \Doctrine\Persistence\Event\LoadClassMetadataEventArgs::class,
+        __NAMESPACE__ . '\LoadClassMetadataEventArgs'
+    );
+}
 
 if (false) {
     class LoadClassMetadataEventArgs extends \Doctrine\Persistence\Event\LoadClassMetadataEventArgs

--- a/lib/Doctrine/Common/Persistence/Event/ManagerEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/ManagerEventArgs.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Event;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Event\ManagerEventArgs::class,
-    __NAMESPACE__ . '\ManagerEventArgs'
-);
+if (!class_exists(__NAMESPACE__ . '\ManagerEventArgs')) {
+    class_alias(
+        \Doctrine\Persistence\Event\ManagerEventArgs::class,
+        __NAMESPACE__ . '\ManagerEventArgs'
+    );
+}
 
 if (false) {
     class ManagerEventArgs extends \Doctrine\Persistence\Event\ManagerEventArgs

--- a/lib/Doctrine/Common/Persistence/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/OnClearEventArgs.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Event;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Event\OnClearEventArgs::class,
-    __NAMESPACE__ . '\OnClearEventArgs'
-);
+if (!class_exists(__NAMESPACE__ . '\OnClearEventArgs')) {
+    class_alias(
+        \Doctrine\Persistence\Event\OnClearEventArgs::class,
+        __NAMESPACE__ . '\OnClearEventArgs'
+    );
+}
 
 if (false) {
     class OnClearEventArgs extends \Doctrine\Persistence\Event\OnClearEventArgs

--- a/lib/Doctrine/Common/Persistence/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/PreUpdateEventArgs.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Event;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Event\PreUpdateEventArgs::class,
-    __NAMESPACE__ . '\PreUpdateEventArgs'
-);
+if (!class_exists(__NAMESPACE__ . '\PreUpdateEventArgs')) {
+    class_alias(
+        \Doctrine\Persistence\Event\PreUpdateEventArgs::class,
+        __NAMESPACE__ . '\PreUpdateEventArgs'
+    );
+}
 
 if (false) {
     class PreUpdateEventArgs extends \Doctrine\Persistence\Event\PreUpdateEventArgs

--- a/lib/Doctrine/Common/Persistence/ManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/ManagerRegistry.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\ManagerRegistry::class,
-    __NAMESPACE__ . '\ManagerRegistry'
-);
+if (!class_exists(__NAMESPACE__ . '\ManagerRegistry')) {
+    class_alias(
+        \Doctrine\Persistence\ManagerRegistry::class,
+        __NAMESPACE__ . '\ManagerRegistry'
+    );
+}
 
 if (false) {
     interface ManagerRegistry extends \Doctrine\Persistence\ManagerRegistry

--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::class,
-    __NAMESPACE__ . '\AbstractClassMetadataFactory'
-);
+if (!class_exists(__NAMESPACE__ . '\AbstractClassMetadataFactory')) {
+    class_alias(
+        \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::class,
+        __NAMESPACE__ . '\AbstractClassMetadataFactory'
+    );
+}
 
 if (false) {
     class AbstractClassMetadataFactory extends \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory

--- a/lib/Doctrine/Common/Persistence/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ClassMetadata.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Mapping\ClassMetadata::class,
-    __NAMESPACE__ . '\ClassMetadata'
-);
+if (!class_exists(__NAMESPACE__ . '\ClassMetadata')) {
+    class_alias(
+        \Doctrine\Persistence\Mapping\ClassMetadata::class,
+        __NAMESPACE__ . '\ClassMetadata'
+    );
+}
 
 if (false) {
     interface ClassMetadata extends \Doctrine\Persistence\Mapping\ClassMetadata

--- a/lib/Doctrine/Common/Persistence/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ClassMetadataFactory.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
+if (!class_exists(__NAMESPACE__ . '\ClassMetadataFactory')) {
+    class_alias(
     \Doctrine\Persistence\Mapping\ClassMetadataFactory::class,
     __NAMESPACE__ . '\ClassMetadataFactory'
-);
+    );
+}
 
 if (false) {
     interface ClassMetadataFactory extends \Doctrine\Persistence\Mapping\ClassMetadataFactory

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Mapping\Driver\AnnotationDriver::class,
-    __NAMESPACE__ . '\AnnotationDriver'
-);
+if (!class_exists(__NAMESPACE__ . '\AnnotationDriver')) {
+    class_alias(
+        \Doctrine\Persistence\Mapping\Driver\AnnotationDriver::class,
+        __NAMESPACE__ . '\AnnotationDriver'
+    );
+}
 
 if (false) {
     abstract class AnnotationDriver extends \Doctrine\Persistence\Mapping\Driver\AnnotationDriver

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Mapping\Driver\DefaultFileLocator::class,
-    __NAMESPACE__ . '\DefaultFileLocator'
-);
+if (!class_exists(__NAMESPACE__ . '\DefaultFileLocator')) {
+    class_alias(
+        \Doctrine\Persistence\Mapping\Driver\DefaultFileLocator::class,
+        __NAMESPACE__ . '\DefaultFileLocator'
+    );
+}
 
 if (false) {
     class DefaultFileLocator extends \Doctrine\Persistence\Mapping\Driver\DefaultFileLocator

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Mapping\Driver\FileDriver::class,
-    __NAMESPACE__ . '\FileDriver'
-);
+if (!class_exists(__NAMESPACE__ . '\FileDriver')) {
+    class_alias(
+        \Doctrine\Persistence\Mapping\Driver\FileDriver::class,
+        __NAMESPACE__ . '\FileDriver'
+    );
+}
 
 if (false) {
     abstract class FileDriver extends \Doctrine\Persistence\Mapping\Driver\FileDriver

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/FileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/FileLocator.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Mapping\Driver\FileLocator::class,
-    __NAMESPACE__ . '\FileLocator'
-);
+if (!class_exists(__NAMESPACE__ . '\FileLocator')) {
+    class_alias(
+        \Doctrine\Persistence\Mapping\Driver\FileLocator::class,
+        __NAMESPACE__ . '\FileLocator'
+    );
+}
 
 if (false) {
     interface FileLocator extends \Doctrine\Persistence\Mapping\Driver\FileLocator

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriver.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Mapping\Driver\MappingDriver::class,
-    __NAMESPACE__ . '\MappingDriver'
-);
+if (!class_exists(__NAMESPACE__ . '\MappingDriver')) {
+    class_alias(
+        \Doctrine\Persistence\Mapping\Driver\MappingDriver::class,
+        __NAMESPACE__ . '\MappingDriver'
+    );
+}
 
 if (false) {
     interface MappingDriver extends \Doctrine\Persistence\Mapping\Driver\MappingDriver

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Mapping\Driver\MappingDriverChain::class,
-    __NAMESPACE__ . '\MappingDriverChain'
-);
+if (!class_exists(__NAMESPACE__ . '\MappingDriverChain')) {
+    class_alias(
+        \Doctrine\Persistence\Mapping\Driver\MappingDriverChain::class,
+        __NAMESPACE__ . '\MappingDriverChain'
+    );
+}
 
 if (false) {
     class MappingDriverChain extends \Doctrine\Persistence\Mapping\Driver\MappingDriverChain

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/PHPDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/PHPDriver.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Mapping\Driver\PHPDriver::class,
-    __NAMESPACE__ . '\PHPDriver'
-);
+if (!class_exists(__NAMESPACE__ . '\PHPDriver')) {
+    class_alias(
+        \Doctrine\Persistence\Mapping\Driver\PHPDriver::class,
+        __NAMESPACE__ . '\PHPDriver'
+    );
+}
 
 if (false) {
     class PHPDriver extends \Doctrine\Persistence\Mapping\Driver\PHPDriver

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/StaticPHPDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/StaticPHPDriver.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Mapping\Driver\StaticPHPDriver::class,
-    __NAMESPACE__ . '\StaticPHPDriver'
-);
+if (!class_exists(__NAMESPACE__ . '\StaticPHPDriver')) {
+    class_alias(
+        \Doctrine\Persistence\Mapping\Driver\StaticPHPDriver::class,
+        __NAMESPACE__ . '\StaticPHPDriver'
+    );
+}
 
 if (false) {
     class StaticPHPDriver extends \Doctrine\Persistence\Mapping\Driver\StaticPHPDriver

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/SymfonyFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/SymfonyFileLocator.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator::class,
-    __NAMESPACE__ . '\SymfonyFileLocator'
-);
+if (!class_exists(__NAMESPACE__ . '\SymfonyFileLocator')) {
+    class_alias(
+        \Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator::class,
+        __NAMESPACE__ . '\SymfonyFileLocator'
+    );
+}
 
 if (false) {
     class SymfonyFileLocator extends \Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator

--- a/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Mapping\MappingException::class,
-    __NAMESPACE__ . '\MappingException'
-);
+if (!class_exists(__NAMESPACE__ . '\MappingException')) {
+    class_alias(
+        \Doctrine\Persistence\Mapping\MappingException::class,
+        __NAMESPACE__ . '\MappingException'
+    );
+}
 
 if (false) {
     class MappingException extends \Doctrine\Persistence\Mapping\MappingException

--- a/lib/Doctrine/Common/Persistence/Mapping/ReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ReflectionService.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Mapping\ReflectionService::class,
-    __NAMESPACE__ . '\ReflectionService'
-);
+if (!class_exists(__NAMESPACE__ . '\ReflectionService')) {
+    class_alias(
+        \Doctrine\Persistence\Mapping\ReflectionService::class,
+        __NAMESPACE__ . '\ReflectionService'
+    );
+}
 
 if (false) {
     interface ReflectionService extends \Doctrine\Persistence\Mapping\ReflectionService

--- a/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Mapping\RuntimeReflectionService::class,
-    __NAMESPACE__ . '\RuntimeReflectionService'
-);
+if (!class_exists(__NAMESPACE__ . '\RuntimeReflectionService')) {
+    class_alias(
+        \Doctrine\Persistence\Mapping\RuntimeReflectionService::class,
+        __NAMESPACE__ . '\RuntimeReflectionService'
+    );
+}
 
 if (false) {
     class RuntimeReflectionService extends \Doctrine\Persistence\Mapping\RuntimeReflectionService

--- a/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence\Mapping;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Mapping\StaticReflectionService::class,
-    __NAMESPACE__ . '\StaticReflectionService'
-);
+if (!class_exists(__NAMESPACE__ . '\StaticReflectionService')) {
+    class_alias(
+        \Doctrine\Persistence\Mapping\StaticReflectionService::class,
+        __NAMESPACE__ . '\StaticReflectionService'
+    );
+}
 
 if (false) {
     class StaticReflectionService extends \Doctrine\Persistence\Mapping\StaticReflectionService

--- a/lib/Doctrine/Common/Persistence/ObjectManager.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManager.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\ObjectManager::class,
-    __NAMESPACE__ . '\ObjectManager'
-);
+if (!class_exists(__NAMESPACE__ . '\ObjectManager')) {
+    class_alias(
+        \Doctrine\Persistence\ObjectManager::class,
+        __NAMESPACE__ . '\ObjectManager'
+    );
+}
 
 if (false) {
     interface ObjectManager extends \Doctrine\Persistence\ObjectManager

--- a/lib/Doctrine/Common/Persistence/ObjectManagerAware.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManagerAware.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\ObjectManagerAware::class,
-    __NAMESPACE__ . '\ObjectManagerAware'
-);
+if (!class_exists(__NAMESPACE__ . '\ObjectManagerAware')) {
+    class_alias(
+        \Doctrine\Persistence\ObjectManagerAware::class,
+        __NAMESPACE__ . '\ObjectManagerAware'
+    );
+}
 
 if (false) {
     interface ObjectManagerAware extends \Doctrine\Persistence\ObjectManagerAware

--- a/lib/Doctrine/Common/Persistence/ObjectManagerDecorator.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManagerDecorator.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\ObjectManagerDecorator::class,
-    __NAMESPACE__ . '\ObjectManagerDecorator'
-);
+if (!class_exists(__NAMESPACE__ . '\ObjectManagerDecorator')) {
+    class_alias(
+        \Doctrine\Persistence\ObjectManagerDecorator::class,
+        __NAMESPACE__ . '\ObjectManagerDecorator'
+    );
+}
 
 if (false) {
     abstract class ObjectManagerDecorator extends \Doctrine\Persistence\ObjectManagerDecorator

--- a/lib/Doctrine/Common/Persistence/ObjectRepository.php
+++ b/lib/Doctrine/Common/Persistence/ObjectRepository.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\ObjectRepository::class,
-    __NAMESPACE__ . '\ObjectRepository'
-);
+if (!class_exists(__NAMESPACE__ . '\ObjectRepository')) {
+    class_alias(
+        \Doctrine\Persistence\ObjectRepository::class,
+        __NAMESPACE__ . '\ObjectRepository'
+    );
+}
 
 if (false) {
     interface ObjectRepository extends \Doctrine\Persistence\ObjectRepository

--- a/lib/Doctrine/Common/Persistence/Proxy.php
+++ b/lib/Doctrine/Common/Persistence/Proxy.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common\Persistence;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\Proxy::class,
-    __NAMESPACE__ . '\Proxy'
-);
+if (!class_exists(__NAMESPACE__ . '\Proxy')) {
+    class_alias(
+        \Doctrine\Persistence\Proxy::class,
+        __NAMESPACE__ . '\Proxy'
+    );
+}
 
 if (false) {
     interface Proxy extends \Doctrine\Persistence\Proxy

--- a/lib/Doctrine/Common/PropertyChangedListener.php
+++ b/lib/Doctrine/Common/PropertyChangedListener.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Common;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(
-    \Doctrine\Persistence\PropertyChangedListener::class,
-    __NAMESPACE__ . '\PropertyChangedListener'
-);
+if (!class_exists(__NAMESPACE__ . '\PropertyChangedListener')) {
+    class_alias(
+        \Doctrine\Persistence\PropertyChangedListener::class,
+        __NAMESPACE__ . '\PropertyChangedListener'
+    );
+}
 
 if (false) {
     interface PropertyChangedListener extends \Doctrine\Persistence\PropertyChangedListener


### PR DESCRIPTION
Fixes: https://github.com/doctrine/persistence/issues/97

This PR add `class_exists` checks before calling the `class_alias` function. I decided to check to _all_ `class_alias` functions.

This fixes the following warnings (in PHP8 RC5 with preloading enabled)
```
<b>Warning</b>:  Can't preload already declared class Doctrine\Common\Persistence\Proxy in <b>/var/www/html/vendor/doctrine/persistence/lib/Doctrine/Common/Persistence/Proxy.php</b> on line <b>13</b><br />
<b>Warning</b>:  Can't preload already declared class Doctrine\Common\Persistence\Mapping\Driver\AnnotationDriver in <b>/var/www/html/vendor/doctrine/persistence/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php</b> on line <b>13</b><br />
<b>Warning</b>:  Can't preload already declared class Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain in <b>/var/www/html/vendor/doctrine/persistence/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php</b> on line <b>13</b><br />
<b>Warning</b>:  Can't preload already declared class Doctrine\Common\Persistence\Mapping\Driver\MappingDriver in <b>/var/www/html/vendor/doctrine/persistence/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriver.php</b> on line <b>13</b><br />
<b>Warning</b>:  Can't preload already declared class Doctrine\Common\Persistence\AbstractManagerRegistry in <b>/var/www/html/vendor/doctrine/persistence/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php</b> on line <b>13</b><br />
<b>Warning</b>:  Can't preload already declared class Doctrine\Common\Persistence\Mapping\ClassMetadata in <b>/var/www/html/vendor/doctrine/persistence/lib/Doctrine/Common/Persistence/Mapping/ClassMetadata.php</b> on line <b>13</b><br />
<b>Warning</b>:  Can't preload already declared class Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs in <b>/var/www/html/vendor/doctrine/persistence/lib/Doctrine/Common/Persistence/Event/LoadClassMetadataEventArgs.php</b> on line <b>13</b><br />
<b>Warning</b>:  Can't preload already declared class Doctrine\Common\Persistence\Event\LifecycleEventArgs in <b>/var/www/html/vendor/doctrine/persistence/lib/Doctrine/Common/Persistence/Event/LifecycleEventArgs.php</b> on line <b>13</b><br />
<b>Warning</b>:  Can't preload already declared class Doctrine\Common\Persistence\ConnectionRegistry in <b>/var/www/html/vendor/doctrine/persistence/lib/Doctrine/Common/Persistence/ConnectionRegistry.php</b> on line <b>13</b><br />
<b>Warning</b>:  Can't preload already declared class Doctrine\Common\Persistence\ManagerRegistry in <b>/var/www/html/vendor/doctrine/persistence/lib/Doctrine/Common/Persistence/ManagerRegistry.php</b> on line <b>13</b><br />
<b>Warning</b>:  Can't preload already declared class Doctrine\Common\Persistence\ObjectRepository in <b>/var/www/html/vendor/doctrine/persistence/lib/Doctrine/Common/Persistence/ObjectRepository.php</b> on line <b>13</b><br />
<b>Warning</b>:  Can't preload already declared class Doctrine\Common\Persistence\ObjectManager in <b>/var/www/html/vendor/doctrine/persistence/lib/Doctrine/Common/Persistence/ObjectManager.php</b> on line <b>13</b
```