### PR TITLE
Deprecate using doctrine/cache in favour of PSR-6

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -1,0 +1,11 @@
+UPGRADE FROM 2.1 to 2.2
+=======================
+
+* Deprecated using doctrine/cache for metadata caching. The `setCacheDriver` and
+  `getCacheDriver` methods in `Doctrine\Persistence\Mapping\AbstractMetadata`
+  have been deprecated. Please use `getCache` and `setCache` with a PSR-6 
+  implementation instead. Note that even after switching to PSR-6,
+  `getCacheDriver` will return a cache instance that wraps the PSR-6 cache.
+  Note that if you use a custom implementation of doctrine/cache, the library
+  may not be able to provide a forward compatibility layer. The cache
+  implementation MUST extend the `Doctrine\Common\Cache\CacheProvider` class.

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "doctrine/cache": "^1.0",
         "doctrine/collections": "^1.0",
         "doctrine/event-manager": "^1.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0|^2.0|^3.0",
         "symfony/cache": "^4.4|^5.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
         "doctrine/annotations": "^1.0",
         "doctrine/cache": "^1.0",
         "doctrine/collections": "^1.0",
-        "doctrine/event-manager": "^1.0"
+        "doctrine/event-manager": "^1.0",
+        "psr/cache": "^1.0",
+        "symfony/cache": "^4.4|^5.0"
     },
     "require-dev": {
         "composer/package-versions-deprecated": "^1.11",

--- a/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -2,17 +2,27 @@
 
 namespace Doctrine\Persistence\Mapping;
 
+use BadMethodCallException;
 use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Proxy;
+use Psr\Cache\CacheItemPoolInterface;
 use ReflectionException;
+use Symfony\Component\Cache\Adapter\DoctrineAdapter;
+use Symfony\Component\Cache\DoctrineProvider;
 
 use function array_reverse;
 use function array_unshift;
 use function explode;
+use function sprintf;
+use function str_replace;
 use function strpos;
 use function strrpos;
 use function substr;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 /**
  * The ClassMetadataFactory is used to create ClassMetadata objects that contain all the
@@ -28,10 +38,13 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @var string
      */
-    protected $cacheSalt = '$CLASSMETADATA';
+    protected $cacheSalt = '__CLASSMETADATA__';
 
     /** @var Cache|null */
     private $cacheDriver;
+
+    /** @var CacheItemPoolInterface|null */
+    private $cache;
 
     /** @var ClassMetadata[] */
     private $loadedMetadata = [];
@@ -45,21 +58,52 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     /**
      * Sets the cache driver used by the factory to cache ClassMetadata instances.
      *
+     * @deprecated setCacheDriver was deprecated in doctrine/persistence 2.2 and will be removed in 3.0. Use setCache instead
+     *
      * @return void
      */
     public function setCacheDriver(?Cache $cacheDriver = null)
     {
+        @trigger_error(sprintf('%s is deprecated. Use setCache() with a PSR-6 cache instead.', __METHOD__), E_USER_DEPRECATED);
+
         $this->cacheDriver = $cacheDriver;
+
+        if ($cacheDriver === null) {
+            $this->cache = null;
+
+            return;
+        }
+
+        if (! $cacheDriver instanceof CacheProvider) {
+            throw new BadMethodCallException('Cannot convert cache to PSR-6 cache');
+        }
+
+        $this->cache = new DoctrineAdapter($cacheDriver);
     }
 
     /**
      * Gets the cache driver used by the factory to cache ClassMetadata instances.
      *
+     * @deprecated getCacheDriver was deprecated in doctrine/persistence 2.2 and will be removed in 3.0. Use getCache instead
+     *
      * @return Cache|null
      */
     public function getCacheDriver()
     {
+        @trigger_error(sprintf('%s is deprecated. Use getCache() instead.', __METHOD__), E_USER_DEPRECATED);
+
         return $this->cacheDriver;
+    }
+
+    public function setCache(CacheItemPoolInterface $cache): void
+    {
+        $this->cache       = $cache;
+        $this->cacheDriver = new DoctrineProvider($cache);
+    }
+
+    public function getCache(): ?CacheItemPoolInterface
+    {
+        return $this->cache;
     }
 
     /**
@@ -174,19 +218,20 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
         $loadingException = null;
 
         try {
-            if ($this->cacheDriver) {
-                $cached = $this->cacheDriver->fetch($realClassName . $this->cacheSalt);
+            if ($this->cache) {
+                $cached = $this->cache->getItem($this->getCacheKey($realClassName))->get();
                 if ($cached instanceof ClassMetadata) {
                     $this->loadedMetadata[$realClassName] = $cached;
 
                     $this->wakeupReflection($cached, $this->getReflectionService());
                 } else {
                     foreach ($this->loadMetadata($realClassName) as $loadedClassName) {
-                        $this->cacheDriver->save(
-                            $loadedClassName . $this->cacheSalt,
-                            $this->loadedMetadata[$loadedClassName]
-                        );
+                        $item = $this->cache->getItem($this->getCacheKey($loadedClassName));
+                        $item->set($this->loadedMetadata[$loadedClassName]);
+                        $this->cache->saveDeferred($item);
                     }
+
+                    $this->cache->commit();
                 }
             } else {
                 $this->loadMetadata($realClassName);
@@ -398,6 +443,11 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
         }
 
         return $this->reflectionService;
+    }
+
+    protected function getCacheKey(string $realClassName): string
+    {
+        return str_replace('\\', '__', $realClassName) . $this->cacheSalt;
     }
 
     /**

--- a/tests/Doctrine/Tests/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -171,11 +171,9 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $item = $this->createMock(CacheItemInterface::class);
 
         $item
-            ->expects(self::any())
             ->method('getKey')
             ->willReturn($key);
         $item
-            ->expects(self::any())
             ->method('get')
             ->willReturn(new stdClass());
         $item
@@ -185,7 +183,6 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
 
         $cacheDriver = $this->createMock(CacheItemPoolInterface::class);
         $cacheDriver
-            ->expects(self::any())
             ->method('getItem')
             ->with($key)
             ->willReturn($item);
@@ -216,7 +213,6 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $item = $this->createMock(CacheItemInterface::class);
 
         $item
-            ->expects(self::any())
             ->method('get')
             ->willReturn(null);
         $item
@@ -241,7 +237,6 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $fallbackCallback = $this->getMockBuilder(stdClass::class)->setMethods(['__invoke'])->getMock();
 
         $fallbackCallback
-            ->expects(self::any())
             ->method('__invoke')
             ->willReturn($metadata);
 

--- a/tests/Doctrine/Tests/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -172,6 +172,10 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
 
         $item
             ->expects(self::any())
+            ->method('getKey')
+            ->willReturn($key);
+        $item
+            ->expects(self::any())
             ->method('get')
             ->willReturn(new stdClass());
         $item
@@ -185,6 +189,11 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
             ->method('getItem')
             ->with($key)
             ->willReturn($item);
+        $cacheDriver
+            ->expects(self::once())
+            ->method('getItems')
+            ->with([$key])
+            ->willReturn([$item]);
         $cacheDriver
             ->expects(self::once())
             ->method('saveDeferred')

--- a/tests/Doctrine/Tests/Persistence/Mapping/TestClassMetadataFactory.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/TestClassMetadataFactory.php
@@ -98,4 +98,9 @@ class TestClassMetadataFactory extends AbstractClassMetadataFactory
 
         return $class !== $name;
     }
+
+    public function getCacheKey(string $realClassName): string
+    {
+        return parent::getCacheKey($realClassName);
+    }
 }


### PR DESCRIPTION
This PR deprecates the `getCacheDriver` and `setCacheDriver` methods in the abstract metadata factory in favour of `setCache` and `getCache` which work with PSR-6 cache instances.

To make the transition easier, this PR provides a full backward and forward compatibility layer. When using `setCache` to use a PSR-6 cache, `getCacheDriver` will expose a doctrine/cache instance that wraps the PSR-6 cache. Similarly, when using `setCacheDriver` with a doctrine/cache instance, `getCache` will expose a PSR-6 cache that wraps the original cache.

The new protected `getCacheKey` method is used to avoid hardcoding cache keys in tests and can also be used by extending implementations to work with cache items directly (although they shouldn't).