### PR TITLE
Introduce proxy class name resolvers

### DIFF
--- a/lib/Doctrine/Persistence/Mapping/ProxyClassNameResolver.php
+++ b/lib/Doctrine/Persistence/Mapping/ProxyClassNameResolver.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\Persistence\Mapping;
+
+interface ProxyClassNameResolver
+{
+    /**
+     * @psalm-param class-string $className
+     * @psalm-return class-string
+     */
+    public function resolveClassName(string $className): string;
+}


### PR DESCRIPTION
The metadata factory tries to resolve a proxy class name to get the real class from it. However, this only works when using proxies from doctrine/common. MongoDB ODM 2 and ORM 3 will use ProxyManager to create proxy objects, which requires workarounds in ODM whenever metadata is fetched.

This PR introduces a small interface that can be used to implement and inject such class name resolvers. If no resolver is defined, it falls back to using the current logic. Note that the resolver is implemented in this package as doctrine/common is a dev dependency and thus not available when doctrine/persistence is used in userland code.