### PR TITLE
Allow ORM to use `ResolveTargetEntityListener` in ManagerRegistry::getManagerForClass()

### DIFF
--- a/lib/Doctrine/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Persistence/AbstractManagerRegistry.php
@@ -176,10 +176,16 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
             $class = $parentClass->getName();
         }
 
+        $isInterface = $proxyClass->isInterface();
+
         foreach ($this->managers as $id) {
             $manager = $this->getService($id);
 
-            if (! $manager->getMetadataFactory()->isTransient($class)) {
+            if (! $isInterface && ! $manager->getMetadataFactory()->isTransient($class)) {
+                return $manager;
+            }
+
+            if ($isInterface && $manager->getClassMetadata($class)) {
                 return $manager;
             }
         }

--- a/lib/Doctrine/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Persistence/AbstractManagerRegistry.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Persistence;
 
+use Doctrine\Persistence\Mapping\MappingException;
 use InvalidArgumentException;
 use ReflectionClass;
 
@@ -185,8 +186,13 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
                 return $manager;
             }
 
-            if ($isInterface && $manager->getClassMetadata($class)) {
-                return $manager;
+            if ($isInterface) {
+                try {
+                    $manager->getClassMetadata($class);
+
+                    return $manager;
+                } catch (MappingException $expected) {
+                }
             }
         }
 


### PR DESCRIPTION
I am not quite sure if this is the right place to ask, because the change aims at a feature of ORM. Anyways, here it goes:

Doctrine ORM features a [ResolveTargetEntityListener](https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/cookbook/resolve-target-entity-listener.html). This mechanism allows to use _Interface_ names in various places, for example in Association Mappings or when querying Repositories from Entity Managers.

It would be helpful if the `AbstractManagerRegistry` could support looking up Managers by such interfaces as well.

The problem with the current implementation is that it makes use of the `isTransient` property. Probably this happens to speed up things: Inside the Metadata Factory, the Driver can determine `isTransient()` more easily, without loading the full metadata.

Interfaces, however, are (to my understanding) always transient, so `getManagerForClass()` never works for them. This is where this PR hopes to improve things without affecting performance for existing use cases.

Will add tests once I get basic approval and :+1:s.

*Background:* `ManagerRegistry::getManagerForClass()` is used inside https://github.com/sensiolabs/SensioFrameworkExtraBundle for the Symfony Framework. So-called "ParamConverters" can automagically fetch (ORM) Entities for request parameters and pass those into Controller classes, reducing boilerplate code. It would be great if we could make this work as well for "resolved target entities".