### PR TITLE
Drop support for PHP 7.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"
@@ -24,7 +23,7 @@ jobs:
           - "normal"
         include:
           - deps: "low"
-            php-version: "7.1"
+            php-version: "7.2"
 
     steps:
       - name: "Checkout"
@@ -34,17 +33,9 @@ jobs:
 
       - name: "Install PHP with pcov"
         uses: "shivammathur/setup-php@v2"
-        if: "${{ matrix.php-version != '7.1' }}"
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
-
-      - name: "Install PHP with xdebug"
-        uses: "shivammathur/setup-php@v2"
-        if: "${{ matrix.php-version == '7.1' }}"
-        with:
-          php-version: "${{ matrix.php-version }}"
-          coverage: "xdebug"
 
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v2"
@@ -59,10 +50,6 @@ jobs:
       - name: "Remove dependency on vimeo/psalm for PHP8"
         run: "composer remove --dev --no-update vimeo/psalm"
         if: "${{ matrix.php-version == '8.0' }}"
-
-      - name: "Downgrade Composer"
-        run: "composer self-update --1"
-        if: "${{ matrix.php-version == '7.1' }}"
 
       - name: "Update dependencies with composer"
         run: "composer update --no-interaction --no-progress --no-suggest"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         {"name": "Marco Pivetta", "email": "ocramius@gmail.com"}
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.2 || ^8.0",
         "doctrine/annotations": "^1.0",
         "doctrine/cache": "^1.0",
         "doctrine/collections": "^1.0",
@@ -31,7 +31,7 @@
         "phpstan/phpstan": "^0.12",
         "doctrine/coding-standard": "^6.0 || ^8.0",
         "doctrine/common": "^3.0",
-        "phpunit/phpunit": "^7.5.20 || ^8.0 || ^9.0",
+        "phpunit/phpunit": "^8.5 || ^9.0",
         "vimeo/psalm": "^3.11"
     },
     "conflict": {

--- a/tests/Doctrine/Tests/Persistence/Mapping/DriverChainTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/DriverChainTest.php
@@ -24,10 +24,10 @@ class DriverChainTest extends DoctrineTestCase
                 ->method('isTransient');
 
         $driver2 = $this->createMock(MappingDriver::class);
-        $driver2->expects($this->at(0))
+        $driver2->expects($this->once())
                 ->method('loadMetadataForClass')
                 ->with($this->equalTo($className), $this->equalTo($classMetadata));
-        $driver2->expects($this->at(1))
+        $driver2->expects($this->once())
                 ->method('isTransient')
                 ->with($this->equalTo($className))
                 ->will($this->returnValue(true));


### PR DESCRIPTION
I've seen in other `doctrine` packages that support for `7.1` has been dropped, even `7.2`. I don't know the policy for dropping PHP versions.

I think the order in which the call to `loadMetadataForClass` and `isTransient` is made does not matter in the test I've changed, but maybe I'm wrong.