### PR TITLE
Analyze tests directory with Psalm

### DIFF
--- a/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -113,6 +113,8 @@ abstract class AnnotationDriver implements MappingDriver
      * Append exclude lookup paths to metadata driver.
      *
      * @param string[] $paths
+     *
+     * @return void
      */
     public function addExcludePaths(array $paths)
     {

--- a/lib/Doctrine/Persistence/Mapping/Driver/FileDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/FileDriver.php
@@ -141,6 +141,8 @@ abstract class FileDriver implements MappingDriver
      * @param string $file The mapping file to load.
      *
      * @return ClassMetadata[]
+     *
+     * @psalm-return array<class-string, ClassMetadata>
      */
     abstract protected function loadMappingFile($file);
 
@@ -187,6 +189,8 @@ abstract class FileDriver implements MappingDriver
 
     /**
      * Sets the locator used to discover mapping files by className.
+     *
+     * @return void
      */
     public function setLocator(FileLocator $locator)
     {

--- a/lib/Doctrine/Persistence/Reflection/TypedNoDefaultReflectionProperty.php
+++ b/lib/Doctrine/Persistence/Reflection/TypedNoDefaultReflectionProperty.php
@@ -34,7 +34,7 @@ class TypedNoDefaultReflectionProperty extends ReflectionProperty
         if ($value === null && $this->hasType() && ! $this->getType()->allowsNull()) {
             $propertyName = $this->getName();
 
-            $unsetter = function () use ($propertyName) {
+            $unsetter = function () use ($propertyName): void {
                 unset($this->$propertyName);
             };
             $unsetter = $unsetter->bindTo($object, $this->getDeclaringClass()->getName());

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,11 +3,6 @@ parameters:
         -   "#^Call to an undefined method Doctrine\\\\Tests\\\\Persistence\\\\TestObject\\:\\:.+\\(\\)\\.$#"
 
         -
-            message: "#^Method Doctrine\\\\Tests\\\\Persistence\\\\Mapping\\\\TestFileDriver\\:\\:loadMappingFile\\(\\) should return array\\<Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\> but returns array\\<string, string\\>\\.$#"
-            count: 2
-            path: tests/Doctrine/Tests/Persistence/Mapping/FileDriverTest.php
-
-        -
             message: "#^Parameter \\#3 \\$nsSeparator of class Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\SymfonyFileLocator constructor expects string, null given\\.$#"
             count: 1
             path: tests/Doctrine/Tests/Persistence/Mapping/SymfonyFileLocatorTest.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -9,8 +9,10 @@
 >
     <projectFiles>
         <directory name="lib/Doctrine/Persistence" />
+        <directory name="tests/Doctrine" />
         <ignoreFiles>
             <directory name="vendor" />
+            <file name="tests/Doctrine/Tests/Persistence/Mapping/_files/TestEntity.php" />
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>

--- a/psalm.xml
+++ b/psalm.xml
@@ -34,5 +34,10 @@
                 <file name="lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php"/>
             </errorLevel>
         </NullableReturnStatement>
+        <NullArgument>
+            <errorLevel type="suppress">
+                <file name="tests/Doctrine/Tests/Persistence/Mapping/SymfonyFileLocatorTest.php"/>
+            </errorLevel>
+        </NullArgument>
     </issueHandlers>
 </psalm>

--- a/tests/Doctrine/Tests/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -148,11 +148,9 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $metadata = $this->createMock(ClassMetadata::class);
         assert($metadata instanceof ClassMetadata);
 
-        $fallbackCallback = $this->getMockBuilder(stdClass::class)->setMethods(['__invoke'])->getMock();
-
-        $fallbackCallback->expects(self::any())->method('__invoke')->willReturn($metadata);
-
-        $this->cmf->fallbackCallback = $fallbackCallback;
+        $this->cmf->fallbackCallback = static function () use ($metadata): ClassMetadata {
+            return $metadata;
+        };
 
         self::assertSame($metadata, $this->cmf->getMetadataFor('Foo'));
     }

--- a/tests/Doctrine/Tests/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -116,8 +116,6 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
             return $classMetadata;
         };
 
-        $this->cmf->metadata = null;
-
         self::assertSame($classMetadata, $this->cmf->getMetadataFor('Foo'));
     }
 
@@ -126,8 +124,6 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $this->cmf->fallbackCallback = static function () {
             return null;
         };
-
-        $this->cmf->metadata = null;
 
         $this->expectException(MappingException::class);
 

--- a/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/AnotherGlobalClass.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/AnotherGlobalClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Persistence\Mapping\Fixtures;
+
+final class AnotherGlobalClass
+{
+}

--- a/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/GlobalClass.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/GlobalClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Persistence\Mapping\Fixtures;
+
+final class GlobalClass
+{
+}

--- a/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/TestClassMetadata.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/TestClassMetadata.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Persistence\Mapping\Fixtures;
+
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use LogicException;
+use ReflectionClass;
+
+final class TestClassMetadata implements ClassMetadata
+{
+    /**
+     * @var string
+     * @psalm-var class-string
+     */
+    private $className;
+
+    /**
+     * @psalm-param class-string $className
+     */
+    public function __construct(string $className)
+    {
+        $this->className = $className;
+    }
+
+    /**
+     * @psalm-return class-string
+     */
+    public function getName(): string
+    {
+        return $this->className;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getIdentifier(): array
+    {
+        return ['id'];
+    }
+
+    public function getReflectionClass(): ReflectionClass
+    {
+        return new ReflectionClass($this->getName());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isIdentifier($fieldName): bool
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasField($fieldName): bool
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAssociation($fieldName)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isSingleValuedAssociation($fieldName)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isCollectionValuedAssociation($fieldName)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFieldNames(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierFieldNames(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationNames(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTypeOfField($fieldName)
+    {
+        throw new LogicException('Not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationTargetClass($assocName)
+    {
+        throw new LogicException('Not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isAssociationInverseSide($assocName): bool
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationMappedByTargetField($assocName)
+    {
+        throw new LogicException('Not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierValues($object): array
+    {
+        return [];
+    }
+}

--- a/tests/Doctrine/Tests/Persistence/Mapping/SymfonyFileLocatorTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/SymfonyFileLocatorTest.php
@@ -84,6 +84,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $path   = __DIR__ . '/_files';
         $prefix = 'Foo';
 
+        /** @psalm-suppress NullArgument */
         new SymfonyFileLocator([$path => $prefix], '.yml', null);
     }
 

--- a/tests/Doctrine/Tests/Persistence/Mapping/SymfonyFileLocatorTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/SymfonyFileLocatorTest.php
@@ -84,7 +84,6 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $path   = __DIR__ . '/_files';
         $prefix = 'Foo';
 
-        /** @psalm-suppress NullArgument */
         new SymfonyFileLocator([$path => $prefix], '.yml', null);
     }
 

--- a/tests/Doctrine/Tests/Persistence/Mapping/TestClassMetadataFactory.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/TestClassMetadataFactory.php
@@ -14,13 +14,13 @@ class TestClassMetadataFactory extends AbstractClassMetadataFactory
     /** @var MappingDriver */
     public $driver;
 
-    /** @var ClassMetadata|null */
+    /** @var ClassMetadata */
     public $metadata;
 
     /** @var callable|null */
     public $fallbackCallback;
 
-    public function __construct(MappingDriver $driver, ?ClassMetadata $metadata)
+    public function __construct(MappingDriver $driver, ClassMetadata $metadata)
     {
         $this->driver   = $driver;
         $this->metadata = $metadata;

--- a/tests/Doctrine/Tests/Persistence/RuntimePublicReflectionPropertyTest.php
+++ b/tests/Doctrine/Tests/Persistence/RuntimePublicReflectionPropertyTest.php
@@ -40,10 +40,8 @@ class RuntimePublicReflectionPropertyTest extends TestCase
 
     public function testGetValueOnProxyPublicProperty(): void
     {
-        $getCheckMock = $this->getMockBuilder('stdClass')->setMethods(['callGet'])->getMock();
-        $getCheckMock->expects($this->never())->method('callGet');
-        $initializer = static function () use ($getCheckMock): void {
-            call_user_func($getCheckMock);
+        $initializer = static function (): void {
+            self::fail('The initializer should not be called.');
         };
 
         $mockProxy = new RuntimePublicReflectionPropertyTestProxyMock();


### PR DESCRIPTION
The `TestFileDriver::loadMappingFile()` method now comply with the interface contract returning `ClassMetadata` instances.

EDIT: This would allow to add `class-string` to type declarations.