### PR TITLE
I've added missing phpDoc for flush method in ObjectManager.php

### DIFF
--- a/lib/Doctrine/Persistence/ObjectManager.php
+++ b/lib/Doctrine/Persistence/ObjectManager.php
@@ -107,6 +107,7 @@ interface ObjectManager
      * This effectively synchronizes the in-memory state of managed objects with the
      * database.
      *
+     * @throws UniqueConstraintViolationException
      * @return void
      */
     public function flush();


### PR DESCRIPTION
flush () method can throw UniqueConstraintViolationException and that information was missing in documentation block so I added @throws statement this
will prevent IDE from marking code with warning.