### PR TITLE
Raise Psalm level to 3 and add generics to ClassMetadata

### DIFF
--- a/lib/Doctrine/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Persistence/AbstractManagerRegistry.php
@@ -29,7 +29,10 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /** @var string */
     private $defaultManager;
 
-    /** @var string */
+    /**
+     * @var string
+     * @psalm-var class-string
+     */
     private $proxyInterfaceName;
 
     /**
@@ -39,6 +42,8 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
      * @param string   $defaultConnection
      * @param string   $defaultManager
      * @param string   $proxyInterfaceName
+     *
+     * @psalm-param class-string $proxyInterfaceName
      */
     public function __construct($name, array $connections, array $managers, $defaultConnection, $defaultManager, $proxyInterfaceName)
     {

--- a/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -163,6 +163,8 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * @param string $simpleClassName
      *
      * @return string
+     *
+     * @psalm-return class-string
      */
     abstract protected function getFqcnFromAlias($namespaceAlias, $simpleClassName);
 
@@ -307,6 +309,8 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * @param string $name
      *
      * @return string[]
+     *
+     * @psalm-param class-string $name
      */
     protected function getParentClasses($name)
     {
@@ -337,6 +341,8 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * @param string $name The name of the class for which the metadata should get loaded.
      *
      * @return string[]
+     *
+     * @psalm-param class-string $name
      */
     protected function loadMetadata($name)
     {

--- a/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -208,6 +208,8 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @throws ReflectionException
      * @throws MappingException
+     *
+     * @psalm-param class-string|string $className
      */
     public function getMetadataFor($className)
     {
@@ -433,6 +435,8 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-param class-string|string $class
      */
     public function isTransient($class)
     {
@@ -446,6 +450,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
             $class                              = $this->getFqcnFromAlias($namespaceAlias, $simpleClassName);
         }
 
+        /** @psalm-var class-string $class */
         return $this->getDriver()->isTransient($class);
     }
 

--- a/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -17,6 +17,7 @@ use function array_keys;
 use function array_map;
 use function array_reverse;
 use function array_unshift;
+use function assert;
 use function explode;
 use function sprintf;
 use function str_replace;
@@ -220,6 +221,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
 
             $realClassName = $this->getFqcnFromAlias($namespaceAlias, $simpleClassName);
         } else {
+            /** @psalm-var class-string $className */
             $realClassName = $this->getRealClass($className);
         }
 
@@ -488,6 +490,8 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
         if ($this->proxyClassNameResolver === null) {
             $this->createDefaultProxyClassNameResolver();
         }
+
+        assert($this->proxyClassNameResolver !== null);
 
         return $this->proxyClassNameResolver->resolveClassName($class);
     }

--- a/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
@@ -6,6 +6,8 @@ use ReflectionClass;
 
 /**
  * Contract for a Doctrine persistence layer ClassMetadata class to implement.
+ *
+ * @template T of object
  */
 interface ClassMetadata
 {
@@ -14,7 +16,7 @@ interface ClassMetadata
      *
      * @return string
      *
-     * @psalm-return class-string
+     * @psalm-return class-string<T>
      */
     public function getName();
 
@@ -30,7 +32,7 @@ interface ClassMetadata
     /**
      * Gets the ReflectionClass instance for this mapped class.
      *
-     * @return ReflectionClass
+     * @return ReflectionClass<T>
      */
     public function getReflectionClass();
 

--- a/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
@@ -13,6 +13,8 @@ interface ClassMetadata
      * Gets the fully-qualified class name of this persistent class.
      *
      * @return string
+     *
+     * @psalm-return class-string
      */
     public function getName();
 

--- a/lib/Doctrine/Persistence/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/ClassMetadataFactory.php
@@ -48,6 +48,8 @@ interface ClassMetadataFactory
      * @param string $className
      *
      * @return bool
+     *
+     * @psalm-param class-string $className
      */
     public function isTransient($className);
 }

--- a/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -66,7 +66,7 @@ abstract class AnnotationDriver implements MappingDriver
     /**
      * Name of the entity annotations as keys.
      *
-     * @var array<class-string, mixed>
+     * @var array<class-string, bool|int>
      */
     protected $entityAnnotationClasses = [];
 

--- a/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -66,7 +66,7 @@ abstract class AnnotationDriver implements MappingDriver
     /**
      * Name of the entity annotations as keys.
      *
-     * @var string[]
+     * @var array<class-string, mixed>
      */
     protected $entityAnnotationClasses = [];
 

--- a/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -170,9 +170,7 @@ abstract class AnnotationDriver implements MappingDriver
      * A class is non-transient if it is annotated with an annotation
      * from the {@see AnnotationDriver::entityAnnotationClasses}.
      *
-     * @param string $className
-     *
-     * @return bool
+     * {@inheritDoc}
      */
     public function isTransient($className)
     {

--- a/lib/Doctrine/Persistence/Mapping/Driver/MappingDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/MappingDriver.php
@@ -32,6 +32,8 @@ interface MappingDriver
      * @param string $className
      *
      * @return bool
+     *
+     * @psalm-param class-string $className
      */
     public function isTransient($className);
 }

--- a/lib/Doctrine/Persistence/Mapping/Driver/SymfonyFileLocator.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/SymfonyFileLocator.php
@@ -227,6 +227,6 @@ class SymfonyFileLocator implements FileLocator
             }
         }
 
-        throw MappingException::mappingFileNotFound($className, substr($className, strrpos($className, '\\') + 1) . $this->fileExtension);
+        throw MappingException::mappingFileNotFound($className, substr($className, (int) strrpos($className, '\\') + 1) . $this->fileExtension);
     }
 }

--- a/lib/Doctrine/Persistence/Mapping/MappingException.php
+++ b/lib/Doctrine/Persistence/Mapping/MappingException.php
@@ -49,8 +49,8 @@ class MappingException extends Exception
 
         return new self(sprintf(
             'File mapping drivers must have a valid directory path, ' .
-            'however the given path %s seems to be incorrect!',
-            $path
+            'however the given path "%s" seems to be incorrect!',
+            (string) $path
         ));
     }
 

--- a/lib/Doctrine/Persistence/Mapping/ReflectionService.php
+++ b/lib/Doctrine/Persistence/Mapping/ReflectionService.php
@@ -21,6 +21,9 @@ interface ReflectionService
      * @return string[]
      *
      * @throws MappingException
+     *
+     * @psalm-param class-string $class
+     * @psalm-return class-string[]
      */
     public function getParentClasses($class);
 
@@ -30,6 +33,8 @@ interface ReflectionService
      * @param string $class
      *
      * @return string
+     *
+     * @psalm-param class-string $class
      */
     public function getClassShortName($class);
 
@@ -37,6 +42,8 @@ interface ReflectionService
      * @param string $class
      *
      * @return string
+     *
+     * @psalm-param class-string $class
      */
     public function getClassNamespace($class);
 
@@ -46,6 +53,8 @@ interface ReflectionService
      * @param string $class
      *
      * @return ReflectionClass|null
+     *
+     * @psalm-param class-string $class
      */
     public function getClass($class);
 
@@ -56,6 +65,8 @@ interface ReflectionService
      * @param string $property
      *
      * @return ReflectionProperty|null
+     *
+     * @psalm-param class-string $class
      */
     public function getAccessibleProperty($class, $property);
 
@@ -66,6 +77,8 @@ interface ReflectionService
      * @param mixed $method
      *
      * @return bool
+     *
+     * @psalm-param class-string $class
      */
     public function hasPublicMethod($class, $method);
 }

--- a/lib/Doctrine/Persistence/Mapping/RuntimeReflectionService.php
+++ b/lib/Doctrine/Persistence/Mapping/RuntimeReflectionService.php
@@ -62,6 +62,8 @@ class RuntimeReflectionService implements ReflectionService
 
     /**
      * {@inheritDoc}
+     *
+     * @return ReflectionClass
      */
     public function getClass($class)
     {

--- a/lib/Doctrine/Persistence/Mapping/StaticReflectionService.php
+++ b/lib/Doctrine/Persistence/Mapping/StaticReflectionService.php
@@ -25,8 +25,10 @@ class StaticReflectionService implements ReflectionService
      */
     public function getClassShortName($className)
     {
-        if (strpos($className, '\\') !== false) {
-            $className = substr($className, strrpos($className, '\\') + 1);
+        $nsSeparatorPosition = strrpos($className, '\\');
+
+        if ($nsSeparatorPosition !== false) {
+            $className = substr($className, $nsSeparatorPosition + 1);
         }
 
         return $className;
@@ -39,7 +41,7 @@ class StaticReflectionService implements ReflectionService
     {
         $namespace = '';
         if (strpos($className, '\\') !== false) {
-            $namespace = strrev(substr(strrev($className), strpos(strrev($className), '\\') + 1));
+            $namespace = strrev(substr(strrev($className), (int) strpos(strrev($className), '\\') + 1));
         }
 
         return $namespace;

--- a/lib/Doctrine/Persistence/Reflection/TypedNoDefaultReflectionProperty.php
+++ b/lib/Doctrine/Persistence/Reflection/TypedNoDefaultReflectionProperty.php
@@ -2,7 +2,10 @@
 
 namespace Doctrine\Persistence\Reflection;
 
+use Closure;
 use ReflectionProperty;
+
+use function assert;
 
 /**
  * PHP Typed No Default Reflection Property - special override for typed properties without a default value.
@@ -38,6 +41,9 @@ class TypedNoDefaultReflectionProperty extends ReflectionProperty
                 unset($this->$propertyName);
             };
             $unsetter = $unsetter->bindTo($object, $this->getDeclaringClass()->getName());
+
+            assert($unsetter instanceof Closure);
+
             $unsetter();
 
             return;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12,3 +12,8 @@ parameters:
             message: "#^Method Doctrine\\\\Persistence\\\\Mapping\\\\AbstractClassMetadataFactory\\:\\:getRealClass\\(\\) should return class\\-string\\<T of object\\> but returns class\\-string\\<Doctrine\\\\Persistence\\\\Proxy\\<T of object\\>\\|T of object\\>\\.$#"
             count: 1
             path: lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
+
+        -
+            message: "#^Parameter \\#1 \\$class of method Doctrine\\\\Persistence\\\\Mapping\\\\RuntimeReflectionService\\:\\:getParentClasses\\(\\) expects class-string, string given.$#"
+            count: 1
+            path: tests/Doctrine/Tests/Persistence/Mapping/RuntimeReflectionServiceTest.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -41,17 +41,21 @@
         </NullArgument>
         <PossiblyNullReference>
             <errorLevel type="suppress">
+                <!-- ReflectionProperty::getType() can return null, but there is ReflectionProperty::hasType()
+                check before -->
                 <file name="lib/Doctrine/Persistence/Reflection/TypedNoDefaultReflectionProperty.php"/>
             </errorLevel>
         </PossiblyNullReference>
         <ArgumentTypeCoercion>
             <errorLevel type="suppress">
+                <!-- On purpose to use a non existing class for tests -->
                 <referencedFunction name="RuntimeReflectionServiceTest::testGetParentClassesForAbsentClass"/>
                 <file name="tests/Doctrine/Tests/Persistence/Mapping/RuntimeReflectionServiceTest.php"/>
             </errorLevel>
         </ArgumentTypeCoercion>
         <MoreSpecificReturnType>
             <errorLevel type="suppress">
+                <!-- FileDriver::loadMappingFile() in tests could have a more specific return, but is not needed -->
                 <file name="tests/Doctrine/Tests/Persistence/Mapping/FileDriverTest.php"/>
             </errorLevel>
         </MoreSpecificReturnType>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <psalm
     totallyTyped="false"
-    errorLevel="4"
+    errorLevel="3"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
@@ -39,5 +39,21 @@
                 <file name="tests/Doctrine/Tests/Persistence/Mapping/SymfonyFileLocatorTest.php"/>
             </errorLevel>
         </NullArgument>
+        <PossiblyNullReference>
+            <errorLevel type="suppress">
+                <file name="lib/Doctrine/Persistence/Reflection/TypedNoDefaultReflectionProperty.php"/>
+            </errorLevel>
+        </PossiblyNullReference>
+        <ArgumentTypeCoercion>
+            <errorLevel type="suppress">
+                <referencedFunction name="RuntimeReflectionServiceTest::testGetParentClassesForAbsentClass"/>
+                <file name="tests/Doctrine/Tests/Persistence/Mapping/RuntimeReflectionServiceTest.php"/>
+            </errorLevel>
+        </ArgumentTypeCoercion>
+        <MoreSpecificReturnType>
+            <errorLevel type="suppress">
+                <file name="tests/Doctrine/Tests/Persistence/Mapping/FileDriverTest.php"/>
+            </errorLevel>
+        </MoreSpecificReturnType>
     </issueHandlers>
 </psalm>

--- a/tests/Doctrine/Tests/Persistence/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/AnnotationDriverTest.php
@@ -24,7 +24,7 @@ class AnnotationDriverTest extends TestCase
 
 class SimpleAnnotationDriver extends AnnotationDriver
 {
-    /** @var bool[] */
+    /** @var array<class-string, mixed> */
     protected $entityAnnotationClasses = [Entity::class => true];
 
     /**

--- a/tests/Doctrine/Tests/Persistence/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/AnnotationDriverTest.php
@@ -24,7 +24,7 @@ class AnnotationDriverTest extends TestCase
 
 class SimpleAnnotationDriver extends AnnotationDriver
 {
-    /** @var array<class-string, mixed> */
+    /** @var array<class-string, bool|int> */
     protected $entityAnnotationClasses = [Entity::class => true];
 
     /**

--- a/tests/Doctrine/Tests/Persistence/Mapping/DriverChainTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/DriverChainTest.php
@@ -93,9 +93,11 @@ class DriverChainTest extends DoctrineTestCase
      */
     public function testDefaultDriver(): void
     {
-        $companyDriver    = $this->createMock(MappingDriver::class);
-        $defaultDriver    = $this->createMock(MappingDriver::class);
-        $entityClassName  = 'Doctrine\Tests\ORM\Mapping\DriverChainEntity';
+        $companyDriver = $this->createMock(MappingDriver::class);
+        $defaultDriver = $this->createMock(MappingDriver::class);
+        /** @psalm-var class-string */
+        $entityClassName = 'Doctrine\Tests\ORM\Mapping\DriverChainEntity';
+        /** @psalm-var class-string */
         $managerClassName = 'Doctrine\Tests\Models\Company\CompanyManager';
         $chain            = new MappingDriverChain();
 

--- a/tests/Doctrine/Tests/Persistence/Mapping/DriverChainTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/DriverChainTest.php
@@ -7,6 +7,8 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Tests\DoctrineTestCase;
+use Doctrine\Tests\Persistence\Mapping\Fixtures\Manager\Manager;
+use Doctrine\Tests\Persistence\Mapping\Fixtures\Model;
 use stdClass;
 
 class DriverChainTest extends DoctrineTestCase
@@ -93,12 +95,10 @@ class DriverChainTest extends DoctrineTestCase
      */
     public function testDefaultDriver(): void
     {
-        $companyDriver = $this->createMock(MappingDriver::class);
-        $defaultDriver = $this->createMock(MappingDriver::class);
-        /** @psalm-var class-string */
-        $entityClassName = 'Doctrine\Tests\ORM\Mapping\DriverChainEntity';
-        /** @psalm-var class-string */
-        $managerClassName = 'Doctrine\Tests\Models\Company\CompanyManager';
+        $companyDriver    = $this->createMock(MappingDriver::class);
+        $defaultDriver    = $this->createMock(MappingDriver::class);
+        $entityClassName  = Model::class;
+        $managerClassName = Manager::class;
         $chain            = new MappingDriverChain();
 
         $companyDriver->expects($this->never())
@@ -118,7 +118,7 @@ class DriverChainTest extends DoctrineTestCase
         self::assertNull($chain->getDefaultDriver());
 
         $chain->setDefaultDriver($defaultDriver);
-        $chain->addDriver($companyDriver, 'Doctrine\Tests\Models\Company');
+        $chain->addDriver($companyDriver, 'Doctrine\Tests\Persistence\Mapping\Fixtures\Manager');
 
         self::assertSame($defaultDriver, $chain->getDefaultDriver());
 

--- a/tests/Doctrine/Tests/Persistence/Mapping/DriverChainTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/DriverChainTest.php
@@ -7,6 +7,7 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Tests\DoctrineTestCase;
+use stdClass;
 
 class DriverChainTest extends DoctrineTestCase
 {
@@ -84,7 +85,7 @@ class DriverChainTest extends DoctrineTestCase
         $chain   = new MappingDriverChain();
         $chain->addDriver($driver1, 'Doctrine\Tests\Models\CMS');
 
-        self::assertTrue($chain->isTransient('stdClass'), 'stdClass isTransient');
+        self::assertTrue($chain->isTransient(stdClass::class), 'stdClass isTransient');
     }
 
     /**

--- a/tests/Doctrine/Tests/Persistence/Mapping/FileDriverTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/FileDriverTest.php
@@ -8,6 +8,7 @@ use Doctrine\Persistence\Mapping\Driver\FileLocator;
 use Doctrine\Tests\DoctrineTestCase;
 use Doctrine\Tests\Persistence\Mapping\Fixtures\AnotherGlobalClass;
 use Doctrine\Tests\Persistence\Mapping\Fixtures\GlobalClass;
+use Doctrine\Tests\Persistence\Mapping\Fixtures\NotLoadedClass;
 use Doctrine\Tests\Persistence\Mapping\Fixtures\TestClassMetadata;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
@@ -84,12 +85,12 @@ class FileDriverTest extends DoctrineTestCase
         $locator->expects($this->any())
                 ->method('getAllClassNames')
                 ->with($this->equalTo(null))
-                ->will($this->returnValue(['stdClass']));
+                ->will($this->returnValue([stdClass::class]));
         $driver = new TestFileDriver($locator);
 
         $classNames = $driver->getAllClassNames();
 
-        self::assertSame(['stdClass'], $classNames);
+        self::assertSame([stdClass::class], $classNames);
     }
 
     public function testGetAllClassNamesBothSources(): void
@@ -144,19 +145,19 @@ class FileDriverTest extends DoctrineTestCase
         $locator = $this->newLocator();
         $locator->expects($this->once())
                 ->method('fileExists')
-                ->with($this->equalTo('stdClass2'))
+                ->with($this->equalTo(NotLoadedClass::class))
                 ->will($this->returnValue(false));
 
         $driver = new TestFileDriver($locator);
 
-        self::assertTrue($driver->isTransient('stdClass2'));
+        self::assertTrue($driver->isTransient(NotLoadedClass::class));
     }
 
     public function testNonLocatorFallback(): void
     {
         $driver = new TestFileDriver(__DIR__ . '/_files', '.yml');
-        self::assertTrue($driver->isTransient('stdClass2'));
-        self::assertFalse($driver->isTransient('stdClass'));
+        self::assertTrue($driver->isTransient(NotLoadedClass::class));
+        self::assertFalse($driver->isTransient(stdClass::class));
     }
 
     /**

--- a/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/Manager/Manager.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/Manager/Manager.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Persistence\Mapping\Fixtures\Manager;
+
+final class Manager
+{
+}

--- a/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/Model.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/Model.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Persistence\Mapping\Fixtures;
+
+final class Model
+{
+}

--- a/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/NotLoadedClass.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/NotLoadedClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Persistence\Mapping\Fixtures;
+
+final class NotLoadedClass
+{
+}

--- a/tests/Doctrine/Tests/Persistence/Mapping/RuntimeReflectionServiceTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/RuntimeReflectionServiceTest.php
@@ -6,6 +6,7 @@ use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Persistence\Reflection\RuntimePublicReflectionProperty;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use ReflectionProperty;
 
 use function count;
@@ -51,7 +52,7 @@ class RuntimeReflectionServiceTest extends TestCase
     public function testGetReflectionClass(): void
     {
         $class = $this->reflectionService->getClass(self::class);
-        self::assertInstanceOf('ReflectionClass', $class);
+        self::assertInstanceOf(ReflectionClass::class, $class);
     }
 
     public function testGetMethods(): void

--- a/tests/Doctrine/Tests/Persistence/Mapping/TestClassMetadataFactory.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/TestClassMetadataFactory.php
@@ -92,8 +92,6 @@ class TestClassMetadataFactory extends AbstractClassMetadataFactory
 
     /**
      * {@inheritDoc}
-     *
-     * @param string $class
      */
     public function isTransient($class): bool
     {

--- a/tests/Doctrine/Tests/Persistence/Mapping/TestClassMetadataFactory.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/TestClassMetadataFactory.php
@@ -38,6 +38,7 @@ class TestClassMetadataFactory extends AbstractClassMetadataFactory
      */
     protected function getFqcnFromAlias($namespaceAlias, $simpleClassName)
     {
+        /** @psalm-var class-string */
         return __NAMESPACE__ . '\\' . $simpleClassName;
     }
 

--- a/tests/Doctrine/Tests/Persistence/Mapping/TestClassMetadataFactory.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/TestClassMetadataFactory.php
@@ -92,6 +92,8 @@ class TestClassMetadataFactory extends AbstractClassMetadataFactory
 
     /**
      * {@inheritDoc}
+     *
+     * @param string $class
      */
     public function isTransient($class): bool
     {

--- a/tests/Doctrine/Tests/Persistence/ObjectManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/Persistence/ObjectManagerDecoratorTest.php
@@ -22,7 +22,7 @@ class NullObjectManagerDecorator extends ObjectManagerDecorator
 
 class ObjectManagerDecoratorTest extends TestCase
 {
-    /** @var MockObject|ObjectManager */
+    /** @var MockObject&ObjectManager */
     private $wrapped;
 
     /** @var NullObjectManagerDecorator */

--- a/tests/Doctrine/Tests/Persistence/PersistentObjectTest.php
+++ b/tests/Doctrine/Tests/Persistence/PersistentObjectTest.php
@@ -191,7 +191,7 @@ class TestObjectMetadata implements ClassMetadata
      */
     public function getAssociationTargetClass($assocName): string
     {
-        return __NAMESPACE__ . '\TestObject';
+        return TestObject::class;
     }
 
     /**

--- a/tests/Doctrine/Tests/Persistence/PersistentObjectTest.php
+++ b/tests/Doctrine/Tests/Persistence/PersistentObjectTest.php
@@ -212,7 +212,7 @@ class TestObjectMetadata implements ClassMetadata
 
     public function getName(): string
     {
-        return __NAMESPACE__ . '\TestObject';
+        return TestObject::class;
     }
 
     public function getReflectionClass(): ReflectionClass

--- a/tests/Doctrine/Tests/Persistence/RuntimePublicReflectionPropertyTest.php
+++ b/tests/Doctrine/Tests/Persistence/RuntimePublicReflectionPropertyTest.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Proxy\Proxy;
 use Doctrine\Persistence\Reflection\RuntimePublicReflectionProperty;
 use LogicException;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 use function call_user_func;
 
@@ -59,7 +60,7 @@ class RuntimePublicReflectionPropertyTest extends TestCase
 
     public function testSetValueOnProxyPublicProperty(): void
     {
-        $setCheckMock = $this->getMockBuilder('stdClass')->setMethods(['neverCallSet'])->getMock();
+        $setCheckMock = $this->getMockBuilder(stdClass::class)->setMethods(['neverCallSet'])->getMock();
         $setCheckMock->expects($this->never())->method('neverCallSet');
         $initializer = static function () use ($setCheckMock): void {
             call_user_func([$setCheckMock, 'neverCallSet']);
@@ -80,7 +81,7 @@ class RuntimePublicReflectionPropertyTest extends TestCase
         $reflProperty->setValue($mockProxy, 'otherNewValue');
         self::assertSame('otherNewValue', $mockProxy->checkedProperty);
 
-        $setCheckMock = $this->getMockBuilder('stdClass')->setMethods(['callSet'])->getMock();
+        $setCheckMock = $this->getMockBuilder(stdClass::class)->setMethods(['callSet'])->getMock();
         $setCheckMock->expects($this->once())->method('callSet');
         $initializer = static function () use ($setCheckMock): void {
             call_user_func([$setCheckMock, 'callSet']);


### PR DESCRIPTION
The first commits of this PR are changes in order to raise psalm level to 3. I've used `2.2.x` as base thinking about adding the `ClassMetadata` generics as feature, but maybe I should split the PR in two targeting `2.1.x` with the raising psalm level part.