### PR TITLE
[Reflection] Use default typed property value when setting value to null

### DIFF
--- a/lib/Doctrine/Persistence/Mapping/RuntimeReflectionService.php
+++ b/lib/Doctrine/Persistence/Mapping/RuntimeReflectionService.php
@@ -4,6 +4,7 @@ namespace Doctrine\Persistence\Mapping;
 
 use Doctrine\Persistence\Reflection\RuntimePublicReflectionProperty;
 use Doctrine\Persistence\Reflection\TypedNoDefaultReflectionProperty;
+use Doctrine\Persistence\Reflection\TypedWithDefaultReflectionProperty;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionMethod;
@@ -77,8 +78,12 @@ class RuntimeReflectionService implements ReflectionService
 
         if ($reflectionProperty->isPublic()) {
             $reflectionProperty = new RuntimePublicReflectionProperty($class, $property);
-        } elseif ($this->supportsTypedPropertiesWorkaround && ! array_key_exists($property, $this->getClass($class)->getDefaultProperties())) {
-            $reflectionProperty = new TypedNoDefaultReflectionProperty($class, $property);
+        } elseif ($this->supportsTypedPropertiesWorkaround) {
+            if (array_key_exists($property, $this->getClass($class)->getDefaultProperties())) {
+                $reflectionProperty = new TypedWithDefaultReflectionProperty($class, $property);
+            } else {
+                $reflectionProperty = new TypedNoDefaultReflectionProperty($class, $property);
+            }
         }
 
         $reflectionProperty->setAccessible(true);

--- a/lib/Doctrine/Persistence/Reflection/TypedWithDefaultReflectionProperty.php
+++ b/lib/Doctrine/Persistence/Reflection/TypedWithDefaultReflectionProperty.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Doctrine\Persistence\Reflection;
+
+use ReflectionProperty;
+
+/**
+ * PHP Typed With Default Reflection Property - special override for typed properties with a default value.
+ */
+class TypedWithDefaultReflectionProperty extends ReflectionProperty
+{
+    /**
+     * {@inheritDoc}
+     *
+     * Works around the problem with setting typed default properties to
+     * NULL which is not supported, instead assign default value to property.
+     */
+    public function setValue($object, $value = null)
+    {
+        if ($value === null && $this->hasType() && ! $this->getType()->allowsNull()) {
+            $propertyName      = $this->getName();
+            $defaultProperties = $this->getDeclaringClass()->getDefaultProperties();
+
+            $setter = function () use ($propertyName, $defaultProperties): void {
+                $this->$propertyName = $defaultProperties[$propertyName];
+            };
+            $setter = $setter->bindTo($object, $this->getDeclaringClass()->getName());
+            $setter();
+
+            return;
+        }
+
+        parent::setValue($object, $value);
+    }
+}

--- a/tests/Doctrine/Tests_PHP74/Persistence/Mapping/RuntimeReflectionServiceTest.php
+++ b/tests/Doctrine/Tests_PHP74/Persistence/Mapping/RuntimeReflectionServiceTest.php
@@ -7,8 +7,8 @@ namespace Doctrine\Tests_PHP74\Persistence\Mapping;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Persistence\Reflection\RuntimePublicReflectionProperty;
 use Doctrine\Persistence\Reflection\TypedNoDefaultReflectionProperty;
+use Doctrine\Persistence\Reflection\TypedWithDefaultReflectionProperty;
 use PHPUnit\Framework\TestCase;
-use ReflectionProperty;
 
 /**
  * @group DCOM-93
@@ -37,7 +37,7 @@ class RuntimeReflectionServiceTest extends TestCase
     public function testGetTypedDefaultReflectionProperty(): void
     {
         $reflProp = $this->reflectionService->getAccessibleProperty(self::class, 'typedDefaultProperty');
-        self::assertInstanceOf(ReflectionProperty::class, $reflProp);
+        self::assertInstanceOf(TypedWithDefaultReflectionProperty::class, $reflProp);
         self::assertNotInstanceOf(TypedNoDefaultReflectionProperty::class, $reflProp);
     }
 

--- a/tests/Doctrine/Tests_PHP74/Persistence/Reflection/TypedWithDefaultReflectionPropertyTest.php
+++ b/tests/Doctrine/Tests_PHP74/Persistence/Reflection/TypedWithDefaultReflectionPropertyTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Doctrine\Tests_PHP74\Persistence\Reflection;
+
+use Doctrine\Persistence\Reflection\TypedWithDefaultReflectionProperty;
+use PHPUnit\Framework\TestCase;
+
+class TypedWithDefaultReflectionPropertyTest extends TestCase
+{
+    public function testSetValueNull(): void
+    {
+        $reflection = new TypedWithDefaultReflectionProperty(TypedFooWithDefault::class, 'id');
+        $reflection->setAccessible(true);
+
+        $object = new TypedFooWithDefault();
+        $object->setId(1);
+
+        self::assertTrue($reflection->isInitialized($object));
+
+        $reflection->setValue($object, null);
+
+        self::assertSame(0, $reflection->getValue($object));
+        self::assertTrue($reflection->isInitialized($object));
+    }
+}
+
+class TypedFooWithDefault
+{
+    private int $id = 0;
+
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
Related to https://github.com/doctrine/orm/issues/7999

I'm using typed properties with a default value that is not null. Example:
```php
class Entity {
    /**
     * @ORM\Column(name="id", type="integer")
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="AUTO")
     */
    private int $id = 0;

    public function getId() : int
    {
        return $this->id;
    }
}
```

This works great. When inserting a new entity in the database, the auto incremented id is updated properly.

It means that entities that are not persisted will have a `0` as id and the rest will have another non-zero integer value.

But upon deleting an entity this becomes a problem. The ORM tries to set the `id` property value to `null` and that causes a TypeError:
```
TypeError: Typed property Entity::$id must be int, null used

vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php:1246
vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php:441
vendor/doctrine/orm/lib/Doctrine/ORM/EntityManager.php:376
```

With this change applied, the default value of the `id` property `0` is used again.

Solving the problem.

I'm wondering: Does this make any sense? Is this crazy? Am I overlooking something, or is this the solution? 😊 