### PR TITLE
Add `$orderBy` to ObjectRepository->findOneBy()

### DIFF
--- a/lib/Doctrine/Persistence/ObjectRepository.php
+++ b/lib/Doctrine/Persistence/ObjectRepository.php
@@ -55,12 +55,13 @@ interface ObjectRepository
      * Finds a single object by a set of criteria.
      *
      * @param mixed[] $criteria The criteria.
+     * @param mixed[]|null $orderBy The order by.
      *
      * @return object|null The object.
      *
      * @psalm-return T|null
      */
-    public function findOneBy(array $criteria);
+    public function findOneBy(array $criteria, array $orderBy = null);
 
     /**
      * Returns the class name of the object managed by the repository.


### PR DESCRIPTION
It doesn't make sense the interface has this signature:
```php
interface ObjectRepository
{
    // . . .

    /**
     * Finds a single object by a set of criteria.
     *
     * @param mixed[] $criteria The criteria.
     *
     * @return object|null The object.
     *
     * @psalm-return T|null
     */
    public function findOneBy(array $criteria);
}
```

And the implementation has this one:
```php
class EntityRepository implements ObjectRepository, Selectable
{
    // . . .

    /**
     * Finds a single entity by a set of criteria.
     *
     * @param array      $criteria
     * @param array|null $orderBy
     *
     * @return object|null The entity instance or NULL if the entity can not be found.
     *
     * @psalm-return ?T
     */
    public function findOneBy(array $criteria, array $orderBy = null)
    {
        $persister = $this->_em->getUnitOfWork()->getEntityPersister($this->_entityName);

        return $persister->load($criteria, null, null, [], null, 1, $orderBy);
    }
}
```