### PR TITLE
Describe $orderBy more accurately

### DIFF
--- a/lib/Doctrine/Persistence/ObjectRepository.php
+++ b/lib/Doctrine/Persistence/ObjectRepository.php
@@ -47,6 +47,7 @@ interface ObjectRepository
      *
      * @throws UnexpectedValueException
      *
+     * @psalm-param array<string, 'asc'|'desc'|'ASC'|'DESC'> $orderBy
      * @psalm-return T[]
      */
     public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null);


### PR DESCRIPTION
I took a look at mongodb-odm to check the impact the impact of this, and found something suspicious: https://github.com/doctrine/mongodb-odm/blob/6e42eed57998ad96f3c868ac5b1329a724024463/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php#L930

Maybe the values can only ever be arrays when called through another methods than `loadAll`? I see it's called in `load()` for instance.