### PR TITLE
Use class-string for parameters

### DIFF
--- a/lib/Doctrine/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Persistence/AbstractManagerRegistry.php
@@ -29,7 +29,10 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /** @var string */
     private $defaultManager;
 
-    /** @var string */
+    /**
+     * @var string
+     * @psalm-var class-string
+     */
     private $proxyInterfaceName;
 
     /**
@@ -39,6 +42,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
      * @param string   $defaultConnection
      * @param string   $defaultManager
      * @param string   $proxyInterfaceName
+     * @psalm-param class-string $proxyInterfaceName
      */
     public function __construct($name, array $connections, array $managers, $defaultConnection, $defaultManager, $proxyInterfaceName)
     {

--- a/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -167,6 +167,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * @param string $simpleClassName
      *
      * @return string
+     * @psalm-return class-string
      */
     abstract protected function getFqcnFromAlias($namespaceAlias, $simpleClassName);
 
@@ -307,6 +308,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * Gets an array of parent classes for the given entity class.
      *
      * @param string $name
+     * @psalm-param class-string $name
      *
      * @return string[]
      */
@@ -337,6 +339,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * should be used for reflection.
      *
      * @param string $name The name of the class for which the metadata should get loaded.
+     * @psalm-param class-string $name
      *
      * @return string[]
      */
@@ -431,6 +434,8 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-param class-string|string $class
      */
     public function isTransient($class)
     {

--- a/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
@@ -13,6 +13,7 @@ interface ClassMetadata
      * Gets the fully-qualified class name of this persistent class.
      *
      * @return string
+     * @psalm-return class-string
      */
     public function getName();
 

--- a/lib/Doctrine/Persistence/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/ClassMetadataFactory.php
@@ -51,6 +51,7 @@ interface ClassMetadataFactory
      * This is only the case if it is either mapped directly or as a MappedSuperclass.
      *
      * @param string $className
+     * @psalm-param class-string $className
      *
      * @return bool
      */

--- a/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -66,7 +66,7 @@ abstract class AnnotationDriver implements MappingDriver
     /**
      * Name of the entity annotations as keys.
      *
-     * @var string[]
+     * @var array<class-string, bool|int>
      */
     protected $entityAnnotationClasses = [];
 

--- a/lib/Doctrine/Persistence/Mapping/Driver/MappingDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/MappingDriver.php
@@ -30,6 +30,7 @@ interface MappingDriver
      * This is only the case if it is either mapped as an Entity or a MappedSuperclass.
      *
      * @param string $className
+     * @psalm-param class-string $className
      *
      * @return bool
      */

--- a/lib/Doctrine/Persistence/Mapping/ReflectionService.php
+++ b/lib/Doctrine/Persistence/Mapping/ReflectionService.php
@@ -17,8 +17,10 @@ interface ReflectionService
      * Returns an array of the parent classes (not interfaces) for the given class.
      *
      * @param string $class
+     * @psalm-param class-string $class
      *
      * @return string[]
+     * @psalm-return class-string[]
      *
      * @throws MappingException
      */
@@ -28,6 +30,7 @@ interface ReflectionService
      * Returns the shortname of a class.
      *
      * @param string $class
+     * @psalm-param class-string $class
      *
      * @return string
      */
@@ -35,6 +38,7 @@ interface ReflectionService
 
     /**
      * @param string $class
+     * @psalm-param class-string $class
      *
      * @return string
      */
@@ -44,6 +48,7 @@ interface ReflectionService
      * Returns a reflection class instance or null.
      *
      * @param string $class
+     * @psalm-param class-string $class
      *
      * @return ReflectionClass|null
      */
@@ -54,6 +59,7 @@ interface ReflectionService
      *
      * @param string $class
      * @param string $property
+     * @psalm-param class-string $class
      *
      * @return ReflectionProperty|null
      */
@@ -64,6 +70,7 @@ interface ReflectionService
      *
      * @param mixed $class
      * @param mixed $method
+     * @psalm-param class-string $class
      *
      * @return bool
      */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,3 +6,8 @@ parameters:
             message: "#^Parameter \\#3 \\$nsSeparator of class Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\SymfonyFileLocator constructor expects string, null given\\.$#"
             count: 1
             path: tests/Doctrine/Tests/Persistence/Mapping/SymfonyFileLocatorTest.php
+
+        - # On purpose to make a test fail.
+            message: "#^Parameter \\#1 \\$class of method Doctrine\\\\Persistence\\\\Mapping\\\\RuntimeReflectionService\\:\\:getParentClasses\\(\\) expects class-string, string given.$#"
+            count: 1
+            path: tests/Doctrine/Tests/Persistence/Mapping/RuntimeReflectionServiceTest.php

--- a/tests/Doctrine/Tests/Persistence/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/AnnotationDriverTest.php
@@ -24,7 +24,7 @@ class AnnotationDriverTest extends TestCase
 
 class SimpleAnnotationDriver extends AnnotationDriver
 {
-    /** @var bool[] */
+    /** @var array<class-string, bool|int> */
     protected $entityAnnotationClasses = [Entity::class => true];
 
     /**

--- a/tests/Doctrine/Tests/Persistence/Mapping/DriverChainTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/DriverChainTest.php
@@ -7,6 +7,9 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Tests\DoctrineTestCase;
+use Doctrine\Tests\Persistence\Mapping\Fixtures\Manager\Manager;
+use Doctrine\Tests\Persistence\Mapping\Fixtures\Model;
+use stdClass;
 
 class DriverChainTest extends DoctrineTestCase
 {
@@ -84,7 +87,7 @@ class DriverChainTest extends DoctrineTestCase
         $chain   = new MappingDriverChain();
         $chain->addDriver($driver1, 'Doctrine\Tests\Models\CMS');
 
-        self::assertTrue($chain->isTransient('stdClass'), 'stdClass isTransient');
+        self::assertTrue($chain->isTransient(stdClass::class), 'stdClass isTransient');
     }
 
     /**
@@ -94,8 +97,8 @@ class DriverChainTest extends DoctrineTestCase
     {
         $companyDriver    = $this->createMock(MappingDriver::class);
         $defaultDriver    = $this->createMock(MappingDriver::class);
-        $entityClassName  = 'Doctrine\Tests\ORM\Mapping\DriverChainEntity';
-        $managerClassName = 'Doctrine\Tests\Models\Company\CompanyManager';
+        $entityClassName  = Model::class;
+        $managerClassName = Manager::class;
         $chain            = new MappingDriverChain();
 
         $companyDriver->expects($this->never())
@@ -115,7 +118,7 @@ class DriverChainTest extends DoctrineTestCase
         self::assertNull($chain->getDefaultDriver());
 
         $chain->setDefaultDriver($defaultDriver);
-        $chain->addDriver($companyDriver, 'Doctrine\Tests\Models\Company');
+        $chain->addDriver($companyDriver, 'Doctrine\Tests\Persistence\Mapping\Fixtures\Manager');
 
         self::assertSame($defaultDriver, $chain->getDefaultDriver());
 

--- a/tests/Doctrine/Tests/Persistence/Mapping/FileDriverTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/FileDriverTest.php
@@ -8,6 +8,7 @@ use Doctrine\Persistence\Mapping\Driver\FileLocator;
 use Doctrine\Tests\DoctrineTestCase;
 use Doctrine\Tests\Persistence\Mapping\Fixtures\AnotherGlobalClass;
 use Doctrine\Tests\Persistence\Mapping\Fixtures\GlobalClass;
+use Doctrine\Tests\Persistence\Mapping\Fixtures\NotLoadedClass;
 use Doctrine\Tests\Persistence\Mapping\Fixtures\TestClassMetadata;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
@@ -84,12 +85,12 @@ class FileDriverTest extends DoctrineTestCase
         $locator->expects($this->any())
                 ->method('getAllClassNames')
                 ->with($this->equalTo(null))
-                ->will($this->returnValue(['stdClass']));
+                ->will($this->returnValue([stdClass::class]));
         $driver = new TestFileDriver($locator);
 
         $classNames = $driver->getAllClassNames();
 
-        self::assertSame(['stdClass'], $classNames);
+        self::assertSame([stdClass::class], $classNames);
     }
 
     public function testGetAllClassNamesBothSources(): void
@@ -144,19 +145,19 @@ class FileDriverTest extends DoctrineTestCase
         $locator = $this->newLocator();
         $locator->expects($this->once())
                 ->method('fileExists')
-                ->with($this->equalTo('stdClass2'))
+                ->with($this->equalTo(NotLoadedClass::class))
                 ->will($this->returnValue(false));
 
         $driver = new TestFileDriver($locator);
 
-        self::assertTrue($driver->isTransient('stdClass2'));
+        self::assertTrue($driver->isTransient(NotLoadedClass::class));
     }
 
     public function testNonLocatorFallback(): void
     {
         $driver = new TestFileDriver(__DIR__ . '/_files', '.yml');
-        self::assertTrue($driver->isTransient('stdClass2'));
-        self::assertFalse($driver->isTransient('stdClass'));
+        self::assertTrue($driver->isTransient(NotLoadedClass::class));
+        self::assertFalse($driver->isTransient(stdClass::class));
     }
 
     /**

--- a/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/Manager/Manager.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/Manager/Manager.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Persistence\Mapping\Fixtures\Manager;
+
+final class Manager
+{
+}

--- a/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/Model.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/Model.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Persistence\Mapping\Fixtures;
+
+final class Model
+{
+}

--- a/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/NotLoadedClass.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/NotLoadedClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Persistence\Mapping\Fixtures;
+
+final class NotLoadedClass
+{
+}

--- a/tests/Doctrine/Tests/Persistence/Mapping/RuntimeReflectionServiceTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/RuntimeReflectionServiceTest.php
@@ -6,6 +6,7 @@ use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Persistence\Reflection\RuntimePublicReflectionProperty;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use ReflectionProperty;
 
 use function count;
@@ -51,7 +52,7 @@ class RuntimeReflectionServiceTest extends TestCase
     public function testGetReflectionClass(): void
     {
         $class = $this->reflectionService->getClass(self::class);
-        self::assertInstanceOf('ReflectionClass', $class);
+        self::assertInstanceOf(ReflectionClass::class, $class);
     }
 
     public function testGetMethods(): void

--- a/tests/Doctrine/Tests/Persistence/Mapping/TestClassMetadataFactory.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/TestClassMetadataFactory.php
@@ -38,6 +38,7 @@ class TestClassMetadataFactory extends AbstractClassMetadataFactory
      */
     protected function getFqcnFromAlias($namespaceAlias, $simpleClassName)
     {
+        /** @psalm-var class-string */
         return __NAMESPACE__ . '\\' . $simpleClassName;
     }
 

--- a/tests/Doctrine/Tests/Persistence/PersistentObjectTest.php
+++ b/tests/Doctrine/Tests/Persistence/PersistentObjectTest.php
@@ -191,7 +191,7 @@ class TestObjectMetadata implements ClassMetadata
      */
     public function getAssociationTargetClass($assocName): string
     {
-        return __NAMESPACE__ . '\TestObject';
+        return TestObject::class;
     }
 
     /**
@@ -212,7 +212,7 @@ class TestObjectMetadata implements ClassMetadata
 
     public function getName(): string
     {
-        return __NAMESPACE__ . '\TestObject';
+        return TestObject::class;
     }
 
     public function getReflectionClass(): ReflectionClass

--- a/tests/Doctrine/Tests/Persistence/RuntimePublicReflectionPropertyTest.php
+++ b/tests/Doctrine/Tests/Persistence/RuntimePublicReflectionPropertyTest.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Proxy\Proxy;
 use Doctrine\Persistence\Reflection\RuntimePublicReflectionProperty;
 use LogicException;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 use function call_user_func;
 
@@ -59,7 +60,7 @@ class RuntimePublicReflectionPropertyTest extends TestCase
 
     public function testSetValueOnProxyPublicProperty(): void
     {
-        $setCheckMock = $this->getMockBuilder('stdClass')->setMethods(['neverCallSet'])->getMock();
+        $setCheckMock = $this->getMockBuilder(stdClass::class)->setMethods(['neverCallSet'])->getMock();
         $setCheckMock->expects($this->never())->method('neverCallSet');
         $initializer = static function () use ($setCheckMock): void {
             call_user_func([$setCheckMock, 'neverCallSet']);
@@ -80,7 +81,7 @@ class RuntimePublicReflectionPropertyTest extends TestCase
         $reflProperty->setValue($mockProxy, 'otherNewValue');
         self::assertSame('otherNewValue', $mockProxy->checkedProperty);
 
-        $setCheckMock = $this->getMockBuilder('stdClass')->setMethods(['callSet'])->getMock();
+        $setCheckMock = $this->getMockBuilder(stdClass::class)->setMethods(['callSet'])->getMock();
         $setCheckMock->expects($this->once())->method('callSet');
         $initializer = static function () use ($setCheckMock): void {
             call_user_func([$setCheckMock, 'callSet']);


### PR DESCRIPTION
Since https://github.com/doctrine/persistence/pull/159 has become more difficult to review, this is a part of it that just adds `class-string` param and vars.