### PR TITLE
Remove use of deprecated TestCase::at() method

### DIFF
--- a/tests/Doctrine/Tests/Persistence/Mapping/DriverChainTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/DriverChainTest.php
@@ -24,13 +24,13 @@ class DriverChainTest extends DoctrineTestCase
                 ->method('isTransient');
 
         $driver2 = $this->createMock(MappingDriver::class);
-        $driver2->expects($this->at(0))
+        $driver2->expects($this->once())
                 ->method('loadMetadataForClass')
                 ->with($this->equalTo($className), $this->equalTo($classMetadata));
-        $driver2->expects($this->at(1))
+        $driver2->expects($this->once())
                 ->method('isTransient')
                 ->with($this->equalTo($className))
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $chain->addDriver($driver1, 'Doctrine\Tests\Models\Company');
         $chain->addDriver($driver2, 'Doctrine\Tests\Persistence\Mapping');


### PR DESCRIPTION
For that test it does not add value to check the order of calls.

https://github.com/doctrine/persistence/blob/fdef2dd7da053bc97841fb45b866a7756bfe0f2f/tests/Doctrine/Tests/Persistence/Mapping/DriverChainTest.php#L26-L40

That order is because there is a call first to:

https://github.com/doctrine/persistence/blob/fdef2dd7da053bc97841fb45b866a7756bfe0f2f/tests/Doctrine/Tests/Persistence/Mapping/DriverChainTest.php#L38

and then to:

https://github.com/doctrine/persistence/blob/fdef2dd7da053bc97841fb45b866a7756bfe0f2f/tests/Doctrine/Tests/Persistence/Mapping/DriverChainTest.php#L40

In the same test.