### PR TITLE
Use PSR-6 compatibility classes from doctrine/cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,10 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "doctrine/annotations": "^1.0",
-        "doctrine/cache": "^1.0",
+        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.0",
         "doctrine/event-manager": "^1.0",
-        "psr/cache": "^1.0|^2.0|^3.0",
-        "symfony/cache": "^4.4|^5.0"
+        "psr/cache": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
         "composer/package-versions-deprecated": "^1.11",
@@ -34,6 +33,7 @@
         "doctrine/coding-standard": "^6.0 || ^9.0",
         "doctrine/common": "^3.0",
         "phpunit/phpunit": "^7.5.20 || ^8.0 || ^9.0",
+        "symfony/cache": "^4.4|^5.0",
         "vimeo/psalm": "4.7.0"
     },
     "conflict": {

--- a/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -5,12 +5,12 @@ namespace Doctrine\Persistence\Mapping;
 use BadMethodCallException;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Proxy;
 use Psr\Cache\CacheItemPoolInterface;
 use ReflectionException;
-use Symfony\Component\Cache\Adapter\DoctrineAdapter;
-use Symfony\Component\Cache\DoctrineProvider;
 
 use function array_combine;
 use function array_keys;
@@ -91,7 +91,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
             throw new BadMethodCallException('Cannot convert cache to PSR-6 cache');
         }
 
-        $this->cache = new DoctrineAdapter($cacheDriver);
+        $this->cache = CacheAdapter::wrap($cacheDriver);
     }
 
     /**
@@ -111,7 +111,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     public function setCache(CacheItemPoolInterface $cache): void
     {
         $this->cache       = $cache;
-        $this->cacheDriver = new DoctrineProvider($cache);
+        $this->cacheDriver = DoctrineProvider::wrap($cache);
     }
 
     final protected function getCache(): ?CacheItemPoolInterface

--- a/tests/Doctrine/Tests/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -3,6 +3,8 @@
 namespace Doctrine\Tests\Persistence\Mapping;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Persistence\Mapping\AbstractClassMetadataFactory;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
@@ -13,8 +15,6 @@ use Psr\Cache\CacheItemPoolInterface;
 use ReflectionMethod;
 use stdClass;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Cache\Adapter\DoctrineAdapter;
-use Symfony\Component\Cache\DoctrineProvider;
 
 /**
  * @covers \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory
@@ -40,7 +40,7 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $this->cmf->setCacheDriver($cache);
 
         self::assertSame($cache, $this->cmf->getCacheDriver());
-        self::assertInstanceOf(DoctrineAdapter::class, self::getCache($this->cmf));
+        self::assertInstanceOf(CacheAdapter::class, self::getCache($this->cmf));
 
         $this->cmf->setCacheDriver(null);
         self::assertNull($this->cmf->getCacheDriver());


### PR DESCRIPTION
This removes the dependency on symfony/cache and uses the PSR-6 compatibility classes included in doctrine/cache 1.11 (and 2.0 once it's released).