### PR TITLE
Fix annotation template and add more phpdoc

### DIFF
--- a/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -313,6 +313,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * @psalm-param class-string $name
      *
      * @return string[]
+     * @psalm-return class-string[]
      */
     protected function getParentClasses($name)
     {
@@ -428,9 +429,12 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * Creates a new ClassMetadata instance for the given class name.
      *
      * @param string $className
+     * @psalm-param class-string<T> $className
      *
-     * @return ClassMetadata
+     * @return ClassMetadata<T>
      * @psalm-return CMTemplate
+     *
+     * @template T of object
      */
     abstract protected function newClassMetadataInstance($className);
 

--- a/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
@@ -7,7 +7,7 @@ use ReflectionClass;
 /**
  * Contract for a Doctrine persistence layer ClassMetadata class to implement.
  *
- * @template T of object
+ * @template-covariant T of object
  */
 interface ClassMetadata
 {

--- a/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/TestClassMetadata.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/Fixtures/TestClassMetadata.php
@@ -10,7 +10,7 @@ use ReflectionClass;
 
 /**
  * @template T of object
- * @implements ClassMetadata<T>
+ * @template-implements ClassMetadata<T>
  */
 final class TestClassMetadata implements ClassMetadata
 {

--- a/tests/Doctrine/Tests/Persistence/Mapping/TestClassMetadataFactory.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/TestClassMetadataFactory.php
@@ -9,17 +9,27 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\ReflectionService;
 
+/**
+ * @template CMTemplate of ClassMetadata
+ * @template-extends AbstractClassMetadataFactory<CMTemplate>
+ */
 class TestClassMetadataFactory extends AbstractClassMetadataFactory
 {
     /** @var MappingDriver */
     public $driver;
 
-    /** @var ClassMetadata */
+    /**
+     * @var ClassMetadata
+     * @psalm-var CMTemplate
+     */
     public $metadata;
 
     /** @var callable|null */
     public $fallbackCallback;
 
+    /**
+     * @psalm-param CMTemplate $metadata
+     */
     public function __construct(MappingDriver $driver, ClassMetadata $metadata)
     {
         $this->driver   = $driver;

--- a/tests/Doctrine/Tests/Persistence/PersistentObjectTest.php
+++ b/tests/Doctrine/Tests/Persistence/PersistentObjectTest.php
@@ -166,6 +166,9 @@ class PersistentObjectTest extends DoctrineTestCase
     }
 }
 
+/**
+ * @template-implements ClassMetadata<TestObject>
+ */
 class TestObjectMetadata implements ClassMetadata
 {
     /**


### PR DESCRIPTION
Reviewing again https://github.com/doctrine/persistence/pull/171, just realised that I used in test `@implements` where I meant `@template-implements`.

I raised locally the phpstan level and added some more phpdoc, but it fails:

```
InvalidArgument - tests/Doctrine/Tests/Persistence/PersistentObjectTest.php:55:49 - Argument 2 of Doctrine\Tests\Persistence\TestObject::injectObjectManager expects Doctrine\Persistence\Mapping\ClassMetadata<object>, Doctrine\Tests\Persistence\TestObjectMetadata provided (see https://psalm.dev/004)
        $this->object->injectObjectManager($om, $this->cm);
```

should `ClassMetadata` be declared as `@template-covariant`? there are some other places like:

https://github.com/doctrine/persistence/blob/fb399fefb5570c27c8b15c69c797b0ee559e1fe8/lib/Doctrine/Persistence/Event/LoadClassMetadataEventArgs.php

that I don't know how would be the best way to specify the type of `ClassMetadata` apart from `ClassMetadata<object>`, but I guess it should be declared as covariant for that to work.