### PR TITLE
Removed parameter from ObjectManager::clear()

### DIFF
--- a/docs/en/reference/index.rst
+++ b/docs/en/reference/index.rst
@@ -73,7 +73,7 @@ The main public interface that an end user will use is the ``Doctrine\Persistenc
         public function persist($object);
         public function remove($object);
         public function merge($object);
-        public function clear($objectName = null);
+        public function clear();
         public function detach($object);
         public function refresh($object);
         public function flush();

--- a/lib/Doctrine/Persistence/ObjectManager.php
+++ b/lib/Doctrine/Persistence/ObjectManager.php
@@ -63,10 +63,8 @@ interface ObjectManager
     /**
      * Clears the ObjectManager. All objects that are currently managed
      * by this ObjectManager become detached.
-     *
-     * @param string|null $objectName if given, only objects of this type will get detached.
      */
-    public function clear(?string $objectName = null): void;
+    public function clear(): void;
 
     /**
      * Detaches an object from the ObjectManager, causing a managed object to

--- a/lib/Doctrine/Persistence/ObjectManagerDecorator.php
+++ b/lib/Doctrine/Persistence/ObjectManagerDecorator.php
@@ -38,9 +38,9 @@ abstract class ObjectManagerDecorator implements ObjectManager
         return $this->wrapped->merge($object);
     }
 
-    public function clear(?string $objectName = null): void
+    public function clear(): void
     {
-        $this->wrapped->clear($objectName);
+        $this->wrapped->clear();
     }
 
     public function detach(object $object): void

--- a/tests/Doctrine/Tests/Persistence/ObjectManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/Persistence/ObjectManagerDecoratorTest.php
@@ -73,21 +73,12 @@ class ObjectManagerDecoratorTest extends TestCase
         self::assertSame($object2, $this->decorated->merge($object1));
     }
 
-    public function testClearWithNoArgument(): void
+    public function testClear(): void
     {
         $this->wrapped->expects(self::once())
             ->method('clear');
 
         $this->decorated->clear();
-    }
-
-    public function testClearWithArgument(): void
-    {
-        $this->wrapped->expects(self::once())
-            ->method('clear')
-            ->with(TestObject::class);
-
-        $this->decorated->clear(TestObject::class);
     }
 
     public function testDetach(): void


### PR DESCRIPTION
https://github.com/doctrine/orm/issues/8460

Removed parameter from ObjectManager::clear().

For passing the tests successfully, this PR needs to be merged https://github.com/doctrine/common/pull/928