### PR TITLE
Support Doctrine Cache 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "doctrine/annotations": "^1.0",
-        "doctrine/cache": "^1.0",
+        "doctrine/cache": "^1.0|^2.0",
         "doctrine/collections": "^1.0",
         "doctrine/event-manager": "^1.0"
     },
@@ -32,6 +32,7 @@
         "doctrine/coding-standard": "^6.0 || ^8.0",
         "doctrine/common": "^3.0",
         "phpunit/phpunit": "^7.5.20 || ^8.0 || ^9.0",
+        "symfony/cache": "^4.4",
         "vimeo/psalm": "^4.3.1"
     },
     "conflict": {


### PR DESCRIPTION
This library is already compatible with Doctrine Cache 2 because it only depends on the interfaces. For tests, I've added Symfony Cache because Doctrine Cache 2 does not provide any implementations.