### PR TITLE
Fix Psalm and PHPStan errors for Doctrine Cache 2

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2,6 +2,8 @@ parameters:
     ignoreErrors:
         -   "#^Call to an undefined method Doctrine\\\\Tests\\\\Persistence\\\\TestObject\\:\\:.+\\(\\)\\.$#"
 
+        -   "#^Instantiated class Doctrine\\\\Common\\\\Cache\\\\ArrayCache not found\\.$#"
+
         -
             message: "#^Parameter \\#3 \\$nsSeparator of class Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\SymfonyFileLocator constructor expects string, null given\\.$#"
             count: 1

--- a/psalm.xml
+++ b/psalm.xml
@@ -39,5 +39,11 @@
                 <file name="tests/Doctrine/Tests/Persistence/Mapping/SymfonyFileLocatorTest.php"/>
             </errorLevel>
         </NullArgument>
+        <UndefinedClass>
+            <errorLevel type="suppress">
+                <!-- This test references ArrayCache which has been removed from Doctrine Cache -->
+                <file name="tests/Doctrine/Tests/Persistence/Mapping/ClassMetadataFactoryTest.php"/>
+            </errorLevel>
+        </UndefinedClass>
     </issueHandlers>
 </psalm>

--- a/tests/Doctrine/Tests/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -156,9 +156,12 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
 
     private function getArrayCache(): Cache
     {
-        return class_exists(DoctrineProvider::class)
+        $cache = class_exists(DoctrineProvider::class)
             ? DoctrineProvider::wrap(new ArrayAdapter())
             : new ArrayCache();
+        assert($cache instanceof Cache);
+
+        return $cache;
     }
 }
 


### PR DESCRIPTION
Now that Doctrine Cache 2 has a stable release, Psalm and PHPStan start complaining about the missing Array cache.