### PR TITLE
Use doctrine/deprecations over plain trigger_error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.0",
         "doctrine/event-manager": "^1.0",
-        "psr/cache": "^1.0|^2.0|^3.0"
+        "psr/cache": "^1.0|^2.0|^3.0",
+        "doctrine/deprecations": "^0.5.3"
     },
     "require-dev": {
         "composer/package-versions-deprecated": "^1.11",

--- a/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Proxy;
 use Psr\Cache\CacheItemPoolInterface;
@@ -20,14 +21,10 @@ use function array_unshift;
 use function assert;
 use function explode;
 use function is_array;
-use function sprintf;
 use function str_replace;
 use function strpos;
 use function strrpos;
 use function substr;
-use function trigger_error;
-
-use const E_USER_DEPRECATED;
 
 /**
  * The ClassMetadataFactory is used to create ClassMetadata objects that contain all the
@@ -78,7 +75,12 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      */
     public function setCacheDriver(?Cache $cacheDriver = null)
     {
-        @trigger_error(sprintf('%s is deprecated. Use setCache() with a PSR-6 cache instead.', __METHOD__), E_USER_DEPRECATED);
+        Deprecation::trigger(
+            'doctrine/persistence',
+            'https://github.com/doctrine/persistence/issues/184',
+            '%s is deprecated. Use setCache() with a PSR-6 cache instead.',
+            __METHOD__
+        );
 
         $this->cacheDriver = $cacheDriver;
 
@@ -104,7 +106,12 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      */
     public function getCacheDriver()
     {
-        @trigger_error(sprintf('%s is deprecated. Use getCache() instead.', __METHOD__), E_USER_DEPRECATED);
+        Deprecation::trigger(
+            'doctrine/persistence',
+            'https://github.com/doctrine/persistence/issues/184',
+            '%s is deprecated. Use getCache() instead.',
+            __METHOD__
+        );
 
         return $this->cacheDriver;
     }

--- a/tests/Doctrine/Tests/Persistence/Mapping/AbstractClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/AbstractClassMetadataFactoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Persistence\Mapping;
+
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\Persistence\Mapping\AbstractClassMetadataFactory;
+use Doctrine\Tests\DoctrineTestCase;
+
+final class AbstractClassMetadataFactoryTest extends DoctrineTestCase
+{
+    use VerifyDeprecations;
+
+    public function testSetCacheDriverIsDeprecated(): void
+    {
+        $this->expectDeprecationWithIdentifier(
+            'https://github.com/doctrine/persistence/issues/184'
+        );
+
+        $cmf = $this->getMockForAbstractClass(AbstractClassMetadataFactory::class);
+        $cmf->setCacheDriver(null);
+    }
+
+    public function testGetCacheDriverIsDeprecated(): void
+    {
+        $this->expectDeprecationWithIdentifier(
+            'https://github.com/doctrine/persistence/issues/184'
+        );
+
+        $cmf = $this->getMockForAbstractClass(AbstractClassMetadataFactory::class);
+        $cmf->getCacheDriver();
+    }
+}


### PR DESCRIPTION
It is better for use cases where the deprecated code might get called
many times.