### PR TITLE
Add ReturnTypeWillChange to extended reflection classes

### DIFF
--- a/lib/Doctrine/Persistence/Reflection/RuntimePublicReflectionProperty.php
+++ b/lib/Doctrine/Persistence/Reflection/RuntimePublicReflectionProperty.php
@@ -4,6 +4,7 @@ namespace Doctrine\Persistence\Reflection;
 
 use Doctrine\Common\Proxy\Proxy;
 use ReflectionProperty;
+use ReturnTypeWillChange;
 
 /**
  * PHP Runtime Reflection Public Property - special overrides for public properties.
@@ -17,6 +18,7 @@ class RuntimePublicReflectionProperty extends ReflectionProperty
      * This is to avoid calling `__get` on the provided $object if it
      * is a {@see \Doctrine\Common\Proxy\Proxy}.
      */
+    #[ReturnTypeWillChange]
     public function getValue($object = null)
     {
         $name = $this->getName();
@@ -44,6 +46,7 @@ class RuntimePublicReflectionProperty extends ReflectionProperty
      * @param object $object
      * @param mixed  $value
      */
+    #[ReturnTypeWillChange]
     public function setValue($object, $value = null)
     {
         if (! ($object instanceof Proxy && ! $object->__isInitialized())) {

--- a/lib/Doctrine/Persistence/Reflection/TypedNoDefaultReflectionProperty.php
+++ b/lib/Doctrine/Persistence/Reflection/TypedNoDefaultReflectionProperty.php
@@ -4,6 +4,7 @@ namespace Doctrine\Persistence\Reflection;
 
 use Closure;
 use ReflectionProperty;
+use ReturnTypeWillChange;
 
 use function assert;
 
@@ -21,6 +22,7 @@ class TypedNoDefaultReflectionProperty extends ReflectionProperty
      *
      * @param object $object
      */
+    #[ReturnTypeWillChange]
     public function getValue($object = null)
     {
         return $object !== null && $this->isInitialized($object) ? parent::getValue($object) : null;
@@ -36,6 +38,7 @@ class TypedNoDefaultReflectionProperty extends ReflectionProperty
      *
      * @param object $object
      */
+    #[ReturnTypeWillChange]
     public function setValue($object, $value = null)
     {
         if ($value === null && $this->hasType() && ! $this->getType()->allowsNull()) {


### PR DESCRIPTION
PHP 8.1 will introduce a process to add return types to internal methods, see https://wiki.php.net/rfc/internal_method_return_types

This library extends `ReflectionProperty` and overrides public methods that are affected by this change. PHP 8.1 triggers deprecation warnings unless we declare that a future version of this library will add these return types as well. We can do so by adding the `ReturnTypeWillChange` attribute to those methods.

This PR suggests to do just that because adding the actual return types would break code that extends our classes. As there's already a `3.0.x` branch open, I suggest to add the return types once this PR has been merged up.