### PR TITLE
Don't pass null to strpos()

### DIFF
--- a/tests/Doctrine/Tests/Persistence/Mapping/FileDriverTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/FileDriverTest.php
@@ -180,7 +180,7 @@ class TestFileDriver extends FileDriver
      */
     protected function loadMappingFile($file)
     {
-        if (strpos($file, 'global.yml') !== false) {
+        if ($file && strpos($file, 'global.yml') !== false) {
             return [
                 GlobalClass::class => new TestClassMetadata(GlobalClass::class),
                 AnotherGlobalClass::class => new TestClassMetadata(AnotherGlobalClass::class),


### PR DESCRIPTION
PHP 8.1 will trigger a deprecation warning if we pass `null` to `strpos()`. This PR fixes a test that has triggered such a warning.