### PR TITLE
Allow null as a return value for association's target

### DIFF
--- a/lib/Doctrine/Common/Persistence/PersistentObject.php
+++ b/lib/Doctrine/Common/Persistence/PersistentObject.php
@@ -109,7 +109,7 @@ abstract class PersistentObject implements ObjectManagerAware
             $this->$field = $args[0];
         } elseif ($this->cm->hasAssociation($field) && $this->cm->isSingleValuedAssociation($field)) {
             $targetClass = $this->cm->getAssociationTargetClass($field);
-            if (! ($args[0] instanceof $targetClass) && $args[0] !== null) {
+            if ($targetClass !== null && ! ($args[0] instanceof $targetClass) && $args[0] !== null) {
                 throw new InvalidArgumentException("Expected persistent object of type '" . $targetClass . "'");
             }
 
@@ -181,7 +181,7 @@ abstract class PersistentObject implements ObjectManagerAware
         }
 
         $targetClass = $this->cm->getAssociationTargetClass($field);
-        if (! ($args[0] instanceof $targetClass)) {
+        if ($targetClass !== null && ! ($args[0] instanceof $targetClass)) {
             throw new InvalidArgumentException("Expected persistent object of type '" . $targetClass . "'");
         }
 

--- a/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
@@ -122,8 +122,8 @@ interface ClassMetadata
      *
      * @param string $assocName
      *
-     * @return string
-     * @psalm-return class-string
+     * @return string|null
+     * @psalm-return class-string|null
      */
     public function getAssociationTargetClass($assocName);
 


### PR DESCRIPTION
This came up in https://github.com/doctrine/mongodb-odm/issues/2325 (cc @franmomu @alcaeus ). For the background:

1. ODM has a concept of a discriminator map for references which allows to specify multiple classes a reference can point to, this setting must not be combined with `targetDocument`
2. In ODM you can omit `targetDocument` and `discriminatorMap` altogether to have a reference to any mapped document. Behind the scenes ODM is using FQCN as a discriminator's value 

The change as-is is needed to prevent a break when doctrine/persistence becomes typed. The other solution I see is allowing the method to return an array of FQCNs that would allow ODM to reflect discriminator maps in the method's return value. This would cause a minor inconvenience for ORM I believe, but nothing unseen before (I'm looking at `isSingleValuedAssociation` and similar thing for identifiers).