### PR TITLE
Add .github, .doctrine-project.json and phpstan-baseline.neon to export ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 /docs export-ignore
 /tests export-ignore
+/.github export-ignore
+/.doctrine-project.json export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.scrutinizer.yml export-ignore
@@ -7,5 +9,6 @@
 /phpunit.xml.dist export-ignore
 /phpcs.xml.dist export-ignore
 /phpstan.neon export-ignore
+/phpstan-baseline.neon export-ignore
 /psalm.xml export-ignore
 /composer.lock export-ignore


### PR DESCRIPTION
I think the following files are not required in the export.