### PR TITLE
Handle repeatable attributes in `AnnotationDriver::isTransient`

### DIFF
--- a/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -179,6 +179,10 @@ abstract class AnnotationDriver implements MappingDriver
         $classAnnotations = $this->reader->getClassAnnotations(new ReflectionClass($className));
 
         foreach ($classAnnotations as $annot) {
+            if (is_array($annot)) {
+                $annot = array_pop($annot);
+            }
+
             if (isset($this->entityAnnotationClasses[get_class($annot)])) {
                 return false;
             }


### PR DESCRIPTION
Fixes https://github.com/doctrine/persistence/issues/188

When using multiple attributes:
```php
#[ORM\Entity]
#[ORM\Index(fields: ["customer"])]
#[ORM\Index(fields: ["addressTableId","addressRecordId","addressNumber"])]
class MyEntity
```

Calling `AnnotationDriver::isTransient` fails:
```
TypeError: get_class(): Argument #1 ($object) must be of type object, array given
```

This solves the problem by taking the first attribute of the array (they are all the same) and make sure they are loaded.