### PR TITLE
Remove hard dependency on doctrine/annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "doctrine/annotations": "^1.0",
         "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.0",
         "doctrine/event-manager": "^1.0",
@@ -31,6 +30,7 @@
     "require-dev": {
         "composer/package-versions-deprecated": "^1.11",
         "phpstan/phpstan": "0.12.84",
+        "doctrine/annotations": "^1.0",
         "doctrine/coding-standard": "^6.0 || ^9.0",
         "doctrine/common": "^3.0",
         "phpunit/phpunit": "^7.5.20 || ^8.0 || ^9.0",


### PR DESCRIPTION
It would be great to be able to remove `doctrine/annotations` in projects that fully migrated to attributes. While testing this, we discovered that this package has a hard dependency on it (and thus, it cannot be removed).

The diff of this PR feels a bit weird: I couldn't find any dependency on `doctrine/annotations` in this project (other than the tests).

The `AnnotationDriver` does have a PHPdoc-only typehint to `Doctrine\Common\Annotations\Reader`. The `doctrine/orm` `AttributeDriver` extends this class, but passes a custom `AttributeReader` that doesn't extend from the annotations reader. So I guess that's a reason why the typehint isn't a PHP typehint?