### PR TITLE
Allow null in `ClassMetadata::getTypeOfField` and use string offset for criteria

### DIFF
--- a/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
@@ -113,7 +113,7 @@ interface ClassMetadata
      *
      * @param string $fieldName
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeOfField($fieldName);
 

--- a/lib/Doctrine/Persistence/ObjectRepository.php
+++ b/lib/Doctrine/Persistence/ObjectRepository.php
@@ -36,10 +36,10 @@ interface ObjectRepository
      * an UnexpectedValueException if certain values of the sorting or limiting details are
      * not supported.
      *
-     * @param mixed[]       $criteria
-     * @param string[]|null $orderBy
-     * @param int|null      $limit
-     * @param int|null      $offset
+     * @param array<string, mixed> $criteria
+     * @param string[]|null        $orderBy
+     * @param int|null             $limit
+     * @param int|null             $offset
      * @psalm-param array<string, 'asc'|'desc'|'ASC'|'DESC'> $orderBy
      *
      * @return object[] The objects.
@@ -52,7 +52,7 @@ interface ObjectRepository
     /**
      * Finds a single object by a set of criteria.
      *
-     * @param mixed[] $criteria The criteria.
+     * @param array<string, mixed> $criteria The criteria.
      *
      * @return object|null The object.
      * @psalm-return T|null


### PR DESCRIPTION
#### ClassMetadata

In ORM it has `string|null` as return type:

https://github.com/doctrine/orm/blob/3c805b22b473a8599ebe7fc89d4f15c95b7bee89/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php#L2268-L2282

and also in ODM it can return `null`:

https://github.com/doctrine/mongodb-odm/blob/37ac6436cc0a668b21dcb4f9bc5e41688c4ac508/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php#L2069-L2073

#### Criteria

Also here both implementations use `string` as offset:

ORM: 
- findBy: https://github.com/doctrine/orm/blob/3c805b22b473a8599ebe7fc89d4f15c95b7bee89/lib/Doctrine/ORM/EntityRepository.php#L206
- findOneBy: https://github.com/doctrine/orm/blob/3c805b22b473a8599ebe7fc89d4f15c95b7bee89/lib/Doctrine/ORM/EntityRepository.php#L222
ODM:
- findBy (inherited): https://github.com/doctrine/mongodb-odm/blob/37ac6436cc0a668b21dcb4f9bc5e41688c4ac508/lib/Doctrine/ODM/MongoDB/Repository/DocumentRepository.php#L171
- findOneBy: https://github.com/doctrine/mongodb-odm/blob/37ac6436cc0a668b21dcb4f9bc5e41688c4ac508/lib/Doctrine/ODM/MongoDB/Repository/DocumentRepository.php#L182