### PR TITLE
Deprecate short namespace alias syntax

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -1,0 +1,4 @@
+UPGRADE FROM 2.2 to 2.3
+=======================
+
+* Deprecated using short namespace alias syntax in favor of ::class syntax.

--- a/lib/Doctrine/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Persistence/AbstractManagerRegistry.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Persistence;
 
+use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 use ReflectionClass;
 
@@ -257,6 +258,13 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     {
         // Check for namespace alias
         if (strpos($classNameOrAlias, ':') !== false) {
+            Deprecation::trigger(
+                'doctrine/persistence',
+                'https://github.com/doctrine/persistence/issues/204',
+                'Short namespace aliases such as "%s" are deprecated, use ::class constant instead.',
+                $classNameOrAlias
+            );
+
             [$namespaceAlias, $simpleClassName] = explode(':', $classNameOrAlias, 2);
 
             /** @psalm-var class-string */

--- a/lib/Doctrine/Persistence/ManagerRegistry.php
+++ b/lib/Doctrine/Persistence/ManagerRegistry.php
@@ -54,6 +54,8 @@ interface ManagerRegistry extends ConnectionRegistry
      *
      * This method looks for the alias in all registered object managers.
      *
+     * @deprecated This method is deprecated along with short namespace aliases.
+     *
      * @param string $alias The alias.
      *
      * @return string The full namespace.

--- a/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -166,6 +166,8 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     /**
      * Gets the fully qualified class-name from the namespace alias.
      *
+     * @deprecated This method is deprecated along with short namespace aliases.
+     *
      * @param string $namespaceAlias
      * @param string $simpleClassName
      *
@@ -224,6 +226,13 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
 
         // Check for namespace alias
         if (strpos($className, ':') !== false) {
+            Deprecation::trigger(
+                'doctrine/persistence',
+                'https://github.com/doctrine/persistence/issues/204',
+                'Short namespace aliases such as "%s" are deprecated, use ::class constant instead.',
+                $className
+            );
+
             [$namespaceAlias, $simpleClassName] = explode(':', $className, 2);
 
             $realClassName = $this->getFqcnFromAlias($namespaceAlias, $simpleClassName);
@@ -454,6 +463,13 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
 
         // Check for namespace alias
         if (strpos($class, ':') !== false) {
+            Deprecation::trigger(
+                'doctrine/persistence',
+                'https://github.com/doctrine/persistence/issues/204',
+                'Short namespace aliases such as "%s" are deprecated, use ::class constant instead.',
+                $class
+            );
+
             [$namespaceAlias, $simpleClassName] = explode(':', $class, 2);
             $class                              = $this->getFqcnFromAlias($namespaceAlias, $simpleClassName);
         }

--- a/tests/Doctrine/Tests/Persistence/ManagerRegistryTest.php
+++ b/tests/Doctrine/Tests/Persistence/ManagerRegistryTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\Persistence;
 
 use Closure;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\Persistence\AbstractManagerRegistry;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
@@ -27,6 +28,8 @@ use const PHP_VERSION_ID;
  */
 class ManagerRegistryTest extends DoctrineTestCase
 {
+    use VerifyDeprecations;
+
     /** @var TestManagerRegistry */
     private $mr;
 
@@ -55,6 +58,8 @@ class ManagerRegistryTest extends DoctrineTestCase
 
     public function testGetManagerForInvalidClass(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/persistence/issues/204');
+
         $this->expectException(ReflectionException::class);
         $this->expectExceptionMessage(
             PHP_VERSION_ID < 80000 ?
@@ -67,11 +72,15 @@ class ManagerRegistryTest extends DoctrineTestCase
 
     public function testGetManagerForAliasedClass(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/persistence/issues/204');
+
         self::assertNull($this->mr->getManagerForClass('prefix:TestObject'));
     }
 
     public function testGetManagerForInvalidAliasedClass(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/persistence/issues/204');
+
         $this->expectException(ReflectionException::class);
         $this->expectExceptionMessage(
             PHP_VERSION_ID < 80000 ?

--- a/tests/Doctrine/Tests/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\Persistence\Mapping;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\Persistence\Mapping\AbstractClassMetadataFactory;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
@@ -24,6 +25,8 @@ use function class_exists;
  */
 class ClassMetadataFactoryTest extends DoctrineTestCase
 {
+    use VerifyDeprecations;
+
     /**
      * @var TestClassMetadataFactory
      * @psalm-var TestClassMetadataFactory<ClassMetadata<object>>
@@ -116,6 +119,8 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
 
     public function testGetAliasedMetadata(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/persistence/issues/204');
+
         $this->cmf->getMetadataFor('prefix:ChildEntity');
 
         self::assertTrue($this->cmf->hasMetadataFor(__NAMESPACE__ . '\ChildEntity'));
@@ -127,6 +132,8 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
      */
     public function testGetInvalidAliasedMetadata(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/persistence/issues/204');
+
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage(
             'Class \'Doctrine\Tests\Persistence\Mapping\ChildEntity:Foo\' does not exist'


### PR DESCRIPTION
This PR deprecates short namespace alias in favor of ::class/FQCN syntax.

Fixes https://github.com/doctrine/persistence/issues/204