### PR TITLE
Undeprecate detach

### DIFF
--- a/lib/Doctrine/Persistence/ObjectManager.php
+++ b/lib/Doctrine/Persistence/ObjectManager.php
@@ -83,9 +83,6 @@ interface ObjectManager
      * Objects which previously referenced the detached object will continue to
      * reference it.
      *
-     * @deprecated Detach operation is deprecated and will be removed in Persistence 2.0. Please use
-     *             {@see ObjectManager::clear()} instead.
-     *
      * @param object $object The object to detach.
      *
      * @return void


### PR DESCRIPTION
Let's finally get `detach` off the hook. As discussed we can not deprecate detach without providing a viable alternative and using `clear` isn't one of them.