### PR TITLE
Specify proxy type

### DIFF
--- a/tests/Doctrine/Tests/Persistence/RuntimePublicReflectionPropertyTest.php
+++ b/tests/Doctrine/Tests/Persistence/RuntimePublicReflectionPropertyTest.php
@@ -108,6 +108,8 @@ class RuntimePublicReflectionPropertyTest extends TestCase
 
 /**
  * Mock that simulates proxy public property lazy loading
+ *
+ * @implements Proxy<object>
  */
 class RuntimePublicReflectionPropertyTestProxyMock implements Proxy
 {


### PR DESCRIPTION
It would be hard to be less specific, but also to be more, and this
fixes a PHPStan error.