### PR TITLE
Add template annotation to ObjectManagerDecorator

### DIFF
--- a/lib/Doctrine/Persistence/ObjectManagerDecorator.php
+++ b/lib/Doctrine/Persistence/ObjectManagerDecorator.php
@@ -4,10 +4,12 @@ namespace Doctrine\Persistence;
 
 /**
  * Base class to simplify ObjectManager decorators
+ *
+ * @template-covariant TObjectManager of ObjectManager
  */
 abstract class ObjectManagerDecorator implements ObjectManager
 {
-    /** @var ObjectManager */
+    /** @var TObjectManager */
     protected $wrapped;
 
     /**

--- a/tests/Doctrine/Tests/Persistence/ObjectManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/Persistence/ObjectManagerDecoratorTest.php
@@ -177,6 +177,9 @@ class ObjectManagerDecoratorTest extends TestCase
     }
 }
 
+/**
+ * @extends ObjectManagerDecorator<ObjectManager&MockObject>
+ */
 class NullObjectManagerDecorator extends ObjectManagerDecorator
 {
     /**


### PR DESCRIPTION
Downstream projects like `dcotrine/orm` use the decorator with their own implementations of `ObjectManager`. Adding a template annotation would allow stricter typing without overriding the actual property.