### PR TITLE
Decouple AnnotationDriver from doctrine/annotations

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -2,3 +2,5 @@ UPGRADE FROM 2.2 to 2.3
 =======================
 
 * Deprecated using short namespace alias syntax in favor of ::class syntax.
+* Deprecated passing an annotation reader to `AnnotationDriver::__construct()`.
+* Deprecated not overriding `AnnotationDriver::isTransient()` in a child class.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,6 +9,8 @@
     <!-- Ignore warnings and show progress of the run -->
     <arg value="nps"/>
 
+    <config name="php_version" value="70100"/>
+
     <file>lib</file>
     <file>tests</file>
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,3 +10,12 @@ parameters:
 
     excludePaths:
         - tests/Doctrine/Tests/Persistence/Mapping/_files/Doctrine.Tests.Persistence.Mapping.PHPTestEntity.php
+
+    ignoreErrors:
+        # TODO: Remove in 3.0
+        -
+            message: "#^Call to function is_object\\(\\) with array\\<string\\>\\|string\\|null will always evaluate to false\\.$#"
+            path: lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
+        -
+            message: "#^Parameter \\#1 \\$paths of class Doctrine\\\\Tests\\\\Persistence\\\\Mapping\\\\SimpleAnnotationDriver constructor expects array\\<string\\>\\|string\\|null, Doctrine\\\\Common\\\\Annotations\\\\AnnotationReader given\\.$#"
+            path: tests/Doctrine/Tests/Persistence/Mapping/AnnotationDriverTest.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -22,6 +22,12 @@
                 <file name="lib/Doctrine/Persistence/Reflection/TypedNoDefaultReflectionProperty.php"/>
             </errorLevel>
         </RedundantCondition>
+        <InvalidArgument>
+            <errorLevel type="suppress">
+                <!-- TODO: Remove in 3.0 -->
+                <file name="tests/Doctrine/Tests/Persistence/Mapping/AnnotationDriverTest.php" />
+            </errorLevel>
+        </InvalidArgument>
         <InvalidNullableReturnType>
             <errorLevel type="suppress">
                 <!-- see https://github.com/vimeo/psalm/issues/5193 -->


### PR DESCRIPTION
`AnnotationDriver` is a helpful utility class for all drivers that read metadata from annotated class files. It's main advantage is the ability to search paths for suitable class files.

Unfortunately, it is currently coupled to the doctrine/annotations library. The ORM uses this class for its `AttributeDriver` which feels like a hack currently.

I'd like to decouple the class by removing the `$reader` property and making the `isTransient()` method abstract in 3.0. This PR prepares the necessary deprecation layer.