### PR TITLE
Allow symfony/cache 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "doctrine/coding-standard": "^6.0 || ^9.0",
         "doctrine/common": "^3.0",
         "phpunit/phpunit": "^7.5.20 || ^8.0 || ^9.0",
-        "symfony/cache": "^4.4 || ^5.0",
+        "symfony/cache": "^4.4 || ^5.0 || ^6.0",
         "vimeo/psalm": "4.13.1"
     },
     "conflict": {


### PR DESCRIPTION
Allowing the installation of symfony/cache 6 enables us to run tests with psr/cache 3.