### PR TITLE
Add getFieldMapping and getReflectionProperty methods

### DIFF
--- a/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/Persistence/Mapping/ClassMetadata.php
@@ -3,11 +3,14 @@
 namespace Doctrine\Persistence\Mapping;
 
 use ReflectionClass;
+use ReflectionProperty;
 
 /**
  * Contract for a Doctrine persistence layer ClassMetadata class to implement.
  *
  * @template-covariant T of object
+ * @method array getFieldMapping(string $fieldName)
+ * @method ReflectionProperty getReflectionProperty(string $fieldName)
  */
 interface ClassMetadata
 {


### PR DESCRIPTION
While working with https://github.com/doctrine-extensions/DoctrineExtensions, there are quite calls to these methods: https://github.com/doctrine-extensions/DoctrineExtensions/search?q=getReflectionProperty and https://github.com/doctrine-extensions/DoctrineExtensions/search?q=getFieldMapping

These methods are implemented in the ORM:

https://github.com/doctrine/orm/blob/72edfbc2707c152b633744624e479d7eef04b1d0/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php#L1293-L1300 and https://github.com/doctrine/orm/blob/72edfbc2707c152b633744624e479d7eef04b1d0/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php#L743-L746

MongoDB-odm:

https://github.com/doctrine/mongodb-odm/blob/47642e75ef41e899702d7d43a848b118987c4154/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php#L1799-L1806 and https://github.com/doctrine/mongodb-odm/blob/47642e75ef41e899702d7d43a848b118987c4154/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php#L1322-L1328

PHPCR-odm:

https://github.com/doctrine/phpcr-odm/blob/230312bdb5835f728aa60c82646f035d589dccea/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php#L784-L787 and https://github.com/doctrine/phpcr-odm/blob/230312bdb5835f728aa60c82646f035d589dccea/lib/Doctrine/ODM/PHPCR/Mapping/ClassMetadata.php#L1831-L1838

I don't know if there are other implementations of `ClassMetadata`, there are possible more shared methods that would be nice to have in the interface instead of accessing public properties.

