### PR TITLE
Revert return type declarations

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -20,7 +20,9 @@ Removed support for using doctrine/cache for metadata caching. The
 + public function clear(): void
 ```
 
-Also, native return type declarations have been added on all public APIs.
+Also, native parameter type declarations have been added on all public APIs.
+Native return type declarations have not been added so that it is possible to
+implement types compatible with both 2.x and 3.x.
 
 ## BC Break: Removed `PersistentObject`
 

--- a/lib/Doctrine/Persistence/NotifyPropertyChanged.php
+++ b/lib/Doctrine/Persistence/NotifyPropertyChanged.php
@@ -15,6 +15,8 @@ interface NotifyPropertyChanged
 {
     /**
      * Adds a listener that wants to be notified about property changes.
+     *
+     * @return void
      */
-    public function addPropertyChangedListener(PropertyChangedListener $listener): void;
+    public function addPropertyChangedListener(PropertyChangedListener $listener);
 }

--- a/lib/Doctrine/Persistence/ObjectManager.php
+++ b/lib/Doctrine/Persistence/ObjectManager.php
@@ -26,7 +26,7 @@ interface ObjectManager
      *
      * @template T of object
      */
-    public function find(string $className, $id): ?object;
+    public function find(string $className, $id);
 
     /**
      * Tells the ObjectManager to make an instance managed and persistent.
@@ -37,8 +37,10 @@ interface ObjectManager
      * this ObjectManager as NEW. Do not pass detached objects to the persist operation.
      *
      * @param object $object The instance to make managed and persistent.
+     *
+     * @return void
      */
-    public function persist(object $object): void;
+    public function persist(object $object);
 
     /**
      * Removes an object instance.
@@ -46,14 +48,18 @@ interface ObjectManager
      * A removed object will be removed from the database as a result of the flush operation.
      *
      * @param object $object The object instance to remove.
+     *
+     * @return void
      */
-    public function remove(object $object): void;
+    public function remove(object $object);
 
     /**
      * Clears the ObjectManager. All objects that are currently managed
      * by this ObjectManager become detached.
+     *
+     * @return void
      */
-    public function clear(): void;
+    public function clear();
 
     /**
      * Detaches an object from the ObjectManager, causing a managed object to
@@ -63,23 +69,29 @@ interface ObjectManager
      * reference it.
      *
      * @param object $object The object to detach.
+     *
+     * @return void
      */
-    public function detach(object $object): void;
+    public function detach(object $object);
 
     /**
      * Refreshes the persistent state of an object from the database,
      * overriding any local changes that have not yet been persisted.
      *
      * @param object $object The object to refresh.
+     *
+     * @return void
      */
-    public function refresh(object $object): void;
+    public function refresh(object $object);
 
     /**
      * Flushes all changes to objects that have been queued up to now to the database.
      * This effectively synchronizes the in-memory state of managed objects with the
      * database.
+     *
+     * @return void
      */
-    public function flush(): void;
+    public function flush();
 
     /**
      * Gets the repository for a class.
@@ -90,7 +102,7 @@ interface ObjectManager
      *
      * @template T of object
      */
-    public function getRepository(string $className): ObjectRepository;
+    public function getRepository(string $className);
 
     /**
      * Returns the ClassMetadata descriptor for a class.
@@ -104,24 +116,28 @@ interface ObjectManager
      *
      * @template T of object
      */
-    public function getClassMetadata(string $className): ClassMetadata;
+    public function getClassMetadata(string $className);
 
     /**
      * Gets the metadata factory used to gather the metadata of classes.
      *
      * @psalm-return ClassMetadataFactory<ClassMetadata<object>>
      */
-    public function getMetadataFactory(): ClassMetadataFactory;
+    public function getMetadataFactory();
 
     /**
      * Helper method to initialize a lazy loading proxy or persistent collection.
      *
      * This method is a no-op for other objects.
+     *
+     * @return void
      */
-    public function initializeObject(object $obj): void;
+    public function initializeObject(object $obj);
 
     /**
      * Checks if the object is part of the current UnitOfWork and therefore managed.
+     *
+     * @return bool
      */
-    public function contains(object $object): bool;
+    public function contains(object $object);
 }

--- a/lib/Doctrine/Persistence/ObjectManagerAware.php
+++ b/lib/Doctrine/Persistence/ObjectManagerAware.php
@@ -26,9 +26,11 @@ interface ObjectManagerAware
      * Injects responsible ObjectManager and the ClassMetadata into this persistent object.
      *
      * @psalm-param ClassMetadata<object> $classMetadata
+     *
+     * @return void
      */
     public function injectObjectManager(
         ObjectManager $objectManager,
         ClassMetadata $classMetadata
-    ): void;
+    );
 }

--- a/lib/Doctrine/Persistence/ObjectManagerDecorator.php
+++ b/lib/Doctrine/Persistence/ObjectManagerDecorator.php
@@ -20,17 +20,17 @@ abstract class ObjectManagerDecorator implements ObjectManager
     /**
      * {@inheritdoc}
      */
-    public function find(string $className, $id): ?object
+    public function find(string $className, $id)
     {
         return $this->wrapped->find($className, $id);
     }
 
-    public function persist(object $object): void
+    public function persist(object $object)
     {
         $this->wrapped->persist($object);
     }
 
-    public function remove(object $object): void
+    public function remove(object $object)
     {
         $this->wrapped->remove($object);
     }
@@ -40,27 +40,33 @@ abstract class ObjectManagerDecorator implements ObjectManager
         $this->wrapped->clear();
     }
 
-    public function detach(object $object): void
+    public function detach(object $object)
     {
         $this->wrapped->detach($object);
     }
 
-    public function refresh(object $object): void
+    public function refresh(object $object)
     {
         $this->wrapped->refresh($object);
     }
 
-    public function flush(): void
+    public function flush()
     {
         $this->wrapped->flush();
     }
 
-    public function getRepository(string $className): ObjectRepository
+    /**
+     * {@inheritdoc}
+     */
+    public function getRepository(string $className)
     {
         return $this->wrapped->getRepository($className);
     }
 
-    public function getClassMetadata(string $className): ClassMetadata
+    /**
+     * {@inheritdoc}
+     */
+    public function getClassMetadata(string $className)
     {
         return $this->wrapped->getClassMetadata($className);
     }
@@ -68,17 +74,20 @@ abstract class ObjectManagerDecorator implements ObjectManager
     /**
      * @psalm-return ClassMetadataFactory<ClassMetadata<object>>
      */
-    public function getMetadataFactory(): ClassMetadataFactory
+    public function getMetadataFactory()
     {
         return $this->wrapped->getMetadataFactory();
     }
 
-    public function initializeObject(object $obj): void
+    public function initializeObject(object $obj)
     {
         $this->wrapped->initializeObject($obj);
     }
 
-    public function contains(object $object): bool
+    /**
+     * {@inheritdoc}
+     */
+    public function contains(object $object)
     {
         return $this->wrapped->contains($object);
     }

--- a/lib/Doctrine/Persistence/ObjectRepository.php
+++ b/lib/Doctrine/Persistence/ObjectRepository.php
@@ -21,7 +21,7 @@ interface ObjectRepository
      * @return object|null The object.
      * @psalm-return T|null
      */
-    public function find($id): ?object;
+    public function find($id);
 
     /**
      * Finds all objects in the repository.
@@ -29,7 +29,7 @@ interface ObjectRepository
      * @return array<int, object> The objects.
      * @psalm-return T[]
      */
-    public function findAll(): array;
+    public function findAll();
 
     /**
      * Finds objects by a set of criteria.
@@ -52,7 +52,7 @@ interface ObjectRepository
         ?array $orderBy = null,
         ?int $limit = null,
         ?int $offset = null
-    ): array;
+    );
 
     /**
      * Finds a single object by a set of criteria.
@@ -62,12 +62,12 @@ interface ObjectRepository
      * @return object|null The object.
      * @psalm-return T|null
      */
-    public function findOneBy(array $criteria): ?object;
+    public function findOneBy(array $criteria);
 
     /**
      * Returns the class name of the object managed by the repository.
      *
      * @psalm-return class-string<T>
      */
-    public function getClassName(): string;
+    public function getClassName();
 }

--- a/lib/Doctrine/Persistence/PropertyChangedListener.php
+++ b/lib/Doctrine/Persistence/PropertyChangedListener.php
@@ -17,6 +17,8 @@ interface PropertyChangedListener
      * @param string $propertyName The name of the property that changed.
      * @param mixed  $oldValue     The old value of the property that changed.
      * @param mixed  $newValue     The new value of the property that changed.
+     *
+     * @return void
      */
-    public function propertyChanged(object $sender, string $propertyName, $oldValue, $newValue): void;
+    public function propertyChanged(object $sender, string $propertyName, $oldValue, $newValue);
 }

--- a/lib/Doctrine/Persistence/Proxy.php
+++ b/lib/Doctrine/Persistence/Proxy.php
@@ -25,11 +25,15 @@ interface Proxy
      * Initializes this proxy if its not yet initialized.
      *
      * Acts as a no-op if already initialized.
+     *
+     * @return void
      */
-    public function __load(): void;
+    public function __load();
 
     /**
      * Returns whether this proxy is initialized or not.
+     *
+     * @return bool
      */
-    public function __isInitialized(): bool;
+    public function __isInitialized();
 }


### PR DESCRIPTION
Adding them means downstream projects that define subtypes of ours
cannot create subtypes compatible with both APIs without a BC break, as
they would need to add return types as well, which is a BC break unless
the subtype at hand is a final class.

To make sure I did not do less or more than I should, I used `git diff origin/2.4.x..revert-return-types -S '(public|protected).*\)\:' --pickaxe-regex -p lib/`