### PR TITLE
Cover AbstractClassMetadataFactory::getParentClasses()

### DIFF
--- a/tests/Doctrine/Tests/Persistence/Mapping/AbstractClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/AbstractClassMetadataFactoryTest.php
@@ -6,6 +6,8 @@ namespace Doctrine\Tests\Persistence\Mapping;
 
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\Persistence\Mapping\AbstractClassMetadataFactory;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Tests\DoctrineTestCase;
 
 final class AbstractClassMetadataFactoryTest extends DoctrineTestCase
@@ -31,4 +33,41 @@ final class AbstractClassMetadataFactoryTest extends DoctrineTestCase
         $cmf = $this->getMockForAbstractClass(AbstractClassMetadataFactory::class);
         $cmf->getCacheDriver();
     }
+
+    public function testItSkipsTransientClasses(): void
+    {
+        $cmf = $this->getMockForAbstractClass(AbstractClassMetadataFactory::class);
+        $cmf
+            ->method('newClassMetadataInstance')
+            ->withConsecutive([SomeGrandParentEntity::class], [SomeEntity::class])
+            ->willReturnOnConsecutiveCalls(
+                $this->createMock(ClassMetadata::class),
+                $this->createMock(ClassMetadata::class)
+            );
+        $driver = $this->createMock(MappingDriver::class);
+        $cmf->method('getDriver')
+            ->willReturn($driver);
+
+        $driver->expects($this->exactly(2))
+            ->method('isTransient')
+            ->withConsecutive(
+                [SomeGrandParentEntity::class],
+                [SomeParentEntity::class]
+            )
+            ->willReturnOnConsecutiveCalls(false, true);
+
+        $cmf->getMetadataFor(SomeEntity::class);
+    }
+}
+
+class SomeGrandParentEntity
+{
+}
+
+class SomeParentEntity extends SomeGrandParentEntity
+{
+}
+
+final class SomeEntity extends SomeParentEntity
+{
 }


### PR DESCRIPTION
While working on implementing compatibility with v3 of this lib in the ORM, I found a bug that this test case covers. Merging up in v3 results in a test failure that will be easy to fix.