### PR TITLE
revert to no intermediary variable

### DIFF
--- a/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -286,10 +286,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
         // Collect parent classes, ignoring transient (not-mapped) classes.
         $parentClasses = [];
 
-        $parentClasses = $this->getReflectionService()
-            ->getParentClasses($name);
-
-        foreach (array_reverse($parentClasses) as $parentClass) {
+        foreach (array_reverse($this->getReflectionService()->getParentClasses($name)) as $parentClass) {
             if ($this->getDriver()->isTransient($parentClass)) {
                 continue;
             }


### PR DESCRIPTION
Another name should have been picked for this variable, because not only
did we extract the parent classes into it, we appended them in reverse
order right after that.
Let's revert to the previous situation.