### PR TITLE
Assert AnnotationDriver works with winding paths

### DIFF
--- a/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -220,7 +220,7 @@ abstract class AnnotationDriver implements MappingDriver
             foreach ($iterator as $file) {
                 $sourceFile = $file[0];
 
-                if (! preg_match('(^phar:)i', $sourceFile)) {
+                if (preg_match('(^phar:)i', $sourceFile) === 0) {
                     $sourceFile = realpath($sourceFile);
                 }
 

--- a/tests/Doctrine/Tests/Persistence/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/Persistence/Mapping/AnnotationDriverTest.php
@@ -7,11 +7,15 @@ use Doctrine\Entity;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\AnnotationDriver;
 use Doctrine\TestClass;
+use Generator;
 use PHPUnit\Framework\TestCase;
 
 class AnnotationDriverTest extends TestCase
 {
-    public function testGetAllClassNames(): void
+    /**
+     * @dataProvider pathProvider
+     */
+    public function testGetAllClassNames(string $path): void
     {
         $reader = new AnnotationReader();
         $driver = new SimpleAnnotationDriver($reader, [__DIR__ . '/_files/annotation']);
@@ -19,6 +23,15 @@ class AnnotationDriverTest extends TestCase
         $classes = $driver->getAllClassNames();
 
         self::assertSame([TestClass::class], $classes);
+    }
+
+    /**
+     * @return Generator<string, array{string}>
+     */
+    public function pathProvider(): Generator
+    {
+        yield 'straigthforward path' => [__DIR__ . '/_files/annotation'];
+        yield 'winding path' => [__DIR__ . '/../Mapping/_files/annotation'];
     }
 }
 


### PR DESCRIPTION
This has been broken on the 3.0.x branch. Let us add a test that ensure
this cannot be broken.