### PR TITLE
add enum reflection property

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,12 +50,14 @@
     "autoload-dev": {
         "psr-4": {
             "Doctrine\\Tests\\": "tests/Doctrine/Tests",
-            "Doctrine\\Tests_PHP74\\": "tests/Doctrine/Tests_PHP74"
+            "Doctrine\\Tests_PHP74\\": "tests/Doctrine/Tests_PHP74",
+            "Doctrine\\Tests_PHP81\\": "tests/Doctrine/Tests_PHP81"
         }
     },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/package-versions-deprecated": true
         }
     }
 }

--- a/lib/Doctrine/Persistence/Reflection/EnumReflectionProperty.php
+++ b/lib/Doctrine/Persistence/Reflection/EnumReflectionProperty.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Doctrine\Persistence\Reflection;
+
+use BackedEnum;
+use ReflectionProperty;
+use ReturnTypeWillChange;
+
+/**
+ * PHP Enum Reflection Property - special override for backed enums.
+ */
+class EnumReflectionProperty extends ReflectionProperty
+{
+    /** @var ReflectionProperty */
+    private $originalReflectionProperty;
+
+    /** @var class-string<BackedEnum> */
+    private $enumType;
+
+    /**
+     * @param class-string<BackedEnum> $enumType
+     */
+    public function __construct(ReflectionProperty $originalReflectionProperty, string $enumType)
+    {
+        $this->originalReflectionProperty = $originalReflectionProperty;
+        $this->enumType                   = $enumType;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Converts enum instance to its value.
+     *
+     * @param object|null $object
+     *
+     * @return int|string|null
+     */
+    #[ReturnTypeWillChange]
+    public function getValue($object = null)
+    {
+        if ($object === null) {
+            return null;
+        }
+
+        $enum = $this->originalReflectionProperty->getValue($object);
+
+        if ($enum === null) {
+            return null;
+        }
+
+        return $enum->value;
+    }
+
+    /**
+     * Converts enum value to enum instance.
+     *
+     * @param object $object
+     * @param mixed  $value
+     */
+    public function setValue($object, $value = null): void
+    {
+        if ($value !== null) {
+            $value = $this->enumType::from($value);
+        }
+
+        $this->originalReflectionProperty->setValue($object, $value);
+    }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -54,4 +54,14 @@
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix">
         <exclude-pattern>lib/Doctrine/Persistence/Mapping/MappingException.php</exclude-pattern>
     </rule>
+
+    <rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect">
+        <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/3474 -->
+        <exclude-pattern>tests/Doctrine/Tests_PHP81/Persistence/Reflection/EnumReflectionPropertyTest.php</exclude-pattern>
+    </rule>
+
+    <rule ref="Generic.WhiteSpace.ScopeIndent.IncorrectExact">
+        <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/3474 -->
+        <exclude-pattern>tests/Doctrine/Tests_PHP81/Persistence/Reflection/EnumReflectionPropertyTest.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
         <testsuite name="Doctrine Persistence Test Suite">
             <directory>./tests/Doctrine/Tests</directory>
             <directory phpVersion="7.4" phpVersionOperator=">=">./tests/Doctrine/Tests_PHP74</directory>
+            <directory phpVersion="8.1" phpVersionOperator=">=">./tests/Doctrine/Tests_PHP81</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/Doctrine/Tests_PHP81/Persistence/Reflection/EnumReflectionPropertyTest.php
+++ b/tests/Doctrine/Tests_PHP81/Persistence/Reflection/EnumReflectionPropertyTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Doctrine\Tests_PHP81\Persistence\Reflection;
+
+use Doctrine\Persistence\Reflection\EnumReflectionProperty;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use ValueError;
+
+class EnumReflectionPropertyTest extends TestCase
+{
+    public function testGetValue(): void
+    {
+        $object       = new TypedEnumClass();
+        $reflProperty = new EnumReflectionProperty(new ReflectionProperty(TypedEnumClass::class, 'suit'), Suit::class);
+        self::assertNull($reflProperty->getValue($object));
+        $object->suit = Suit::Clubs;
+        self::assertSame('C', $reflProperty->getValue($object));
+        $object->suit = null;
+        self::assertNull($reflProperty->getValue($object));
+    }
+
+    public function testSetValidValue(): void
+    {
+        $object       = new TypedEnumClass();
+        $object->suit = Suit::Hearts;
+
+        $reflProperty = new EnumReflectionProperty(new ReflectionProperty(TypedEnumClass::class, 'suit'), Suit::class);
+
+        $reflProperty->setValue($object);
+        self::assertNull($reflProperty->getValue($object));
+        /** @psalm-suppress TypeDoesNotContainNull */
+        self::assertNull($object->suit);
+
+        $reflProperty->setValue($object, 'D');
+        self::assertSame('D', $reflProperty->getValue($object));
+        self::assertSame(Suit::Diamonds, $object->suit);
+    }
+
+    public function testSetInvalidValue(): void
+    {
+        $object       = new TypedEnumClass();
+        $reflProperty = new EnumReflectionProperty(new ReflectionProperty(TypedEnumClass::class, 'suit'), Suit::class);
+
+        $this->expectException(ValueError::class);
+        $reflProperty->setValue($object, 'A');
+    }
+}
+
+class TypedEnumClass
+{
+    public ?Suit $suit = null;
+}
+
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}


### PR DESCRIPTION
Reduces code duplication in https://github.com/doctrine/mongodb-odm/pull/2412 and https://github.com/doctrine/orm/pull/9304 by extracting the `EnumReflectionProperty` here. Please take note of slightly changed name and throwing native `ValueException` here instead of `MappingException`.