### PR TITLE
Deprecate MappingException::pathRequired()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,12 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
+# Upgrade to 2.5
+
+## Deprecated `MappingException::pathRequired()`
+
+`MappingException::pathRequiredForDriver()` should be used instead.
+
 # Upgrade to 2.4
 
 ## Deprecated `AnnotationDriver`

--- a/src/Persistence/Mapping/MappingException.php
+++ b/src/Persistence/Mapping/MappingException.php
@@ -28,6 +28,8 @@ class MappingException extends Exception
     }
 
     /**
+     * @deprecated Use pathRequiredForDriver instead
+     *
      * @return self
      */
     public static function pathRequired()


### PR DESCRIPTION
`MappingException::pathRequiredForDriver()` is not coupled to annotations.