### PR TITLE
Deprecate ObjectManagerAware

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 2.5
 
+## Deprecated `ObjectManagerAware`
+
+Along with deprecating `PersistentObject`, deprecating `ObjectManagerAware`
+means deprecating support for active record, which already came with a word of
+warning. Please implement this directly in your application with a `postLoad`
+event if you need active record style functionality.
+
 ## Deprecated `MappingException::pathRequired()`
 
 `MappingException::pathRequiredForDriver()` should be used instead.

--- a/src/Persistence/ObjectManagerAware.php
+++ b/src/Persistence/ObjectManagerAware.php
@@ -17,6 +17,8 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
  * and increase the coupling of database and objects.
  *
  * Every ObjectManager has to implement this functionality itself.
+ *
+ * @deprecated no replacement planned
  */
 interface ObjectManagerAware
 {


### PR DESCRIPTION
We have deprecated `PersistentObject`, which is one half of what is needed
to implement active record. Let us active record support entirely.