### PR TITLE
Stop using ObjectManagerAware in tests

### DIFF
--- a/tests/Persistence/ManagerRegistryTest.php
+++ b/tests/Persistence/ManagerRegistryTest.php
@@ -8,7 +8,6 @@ use Doctrine\Persistence\AbstractManagerRegistry;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\ObjectManager;
-use Doctrine\Persistence\ObjectManagerAware;
 use Doctrine\Persistence\ObjectRepository;
 use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\DoctrineTestCase;
@@ -41,19 +40,22 @@ class ManagerRegistryTest extends DoctrineTestCase
             ['default' => 'default_manager'],
             'default',
             'default',
-            ObjectManagerAware::class,
+            TestProxy::class,
             $this->getManagerFactory()
         );
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testGetManagerForClass(): void
     {
-        self::assertNull($this->mr->getManagerForClass(TestObject::class));
+        $this->mr->getManagerForClass(TestObject::class);
     }
 
     public function testGetManagerForProxyInterface(): void
     {
-        self::assertNull($this->mr->getManagerForClass(ObjectManagerAware::class));
+        self::assertNull($this->mr->getManagerForClass(TestProxy::class));
     }
 
     public function testGetManagerForInvalidClass(): void
@@ -74,10 +76,10 @@ class ManagerRegistryTest extends DoctrineTestCase
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/persistence/issues/204');
 
-        self::assertNull($this->mr->getManagerForClass('prefix:TestObject'));
+        $this->mr->getManagerForClass('prefix:TestObject');
     }
 
-    public function testGetManagerForInvalidAliasedClass(): void
+    public function testGetManagerForInvalidAliasedClasj(): void
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/persistence/issues/204');
 
@@ -123,7 +125,7 @@ class ManagerRegistryTest extends DoctrineTestCase
             ['default' => 'default_manager', 'other' => 'other_manager'],
             'default',
             'default',
-            ObjectManagerAware::class,
+            TestProxy::class,
             $this->getManagerFactory()
         );
 

--- a/tests/Persistence/TestProxy.php
+++ b/tests/Persistence/TestProxy.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Persistence;
+
+interface TestProxy
+{
+}


### PR DESCRIPTION
It also seems some tests were invalid: ObjectManagerAware was used to
avoid creating a custom Proxy interface but really is not. TestObject is
not a proxy, and should not implement it.

To understand this, I found a commit but no pull request in this repository, then I remembered this repository was split from another, so here it is: https://github.com/doctrine/common/pull/387