### PR TITLE
Merge 2.5.x into 3.0.x

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 2.5
 
+## Deprecated `OnClearEventArgs::clearsAllEntities()` and `OnClearEventArgs::getEntityClass()`
+
+These methods only make sense when partially clearing the object manager, which
+is deprecated.
+Passing a second argument to the constructor of `OnClearEventArgs` is
+deprecated as well.
+
 ## Deprecated `ObjectManagerAware`
 
 Along with deprecating `PersistentObject`, deprecating `ObjectManagerAware`

--- a/src/Persistence/Event/OnClearEventArgs.php
+++ b/src/Persistence/Event/OnClearEventArgs.php
@@ -3,7 +3,10 @@
 namespace Doctrine\Persistence\Event;
 
 use Doctrine\Common\EventArgs;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\Persistence\ObjectManager;
+
+use function func_num_args;
 
 /**
  * Provides event arguments for the onClear event.
@@ -22,6 +25,15 @@ class OnClearEventArgs extends EventArgs
      */
     public function __construct($objectManager, $entityClass = null)
     {
+        if (func_num_args() > 1) {
+            Deprecation::trigger(
+                'doctrine/persistence',
+                'https://github.com/doctrine/persistence/pull/270',
+                'The second argument of %s is deprecated and will be removed in 3.0.',
+                __METHOD__
+            );
+        }
+
         $this->objectManager = $objectManager;
         $this->entityClass   = $entityClass;
     }
@@ -37,22 +49,38 @@ class OnClearEventArgs extends EventArgs
     }
 
     /**
+     * @deprecated no replacement planned
      * Returns the name of the entity class that is cleared, or null if all are cleared.
      *
      * @return string|null
      */
     public function getEntityClass()
     {
+        Deprecation::trigger(
+            'doctrine/persistence',
+            'https://github.com/doctrine/persistence/pull/270',
+            '%s is deprecated and will be removed in 3.0',
+            __METHOD__
+        );
+
         return $this->entityClass;
     }
 
     /**
+     * @deprecated no replacement planned
      * Returns whether this event clears all entities.
      *
      * @return bool
      */
     public function clearsAllEntities()
     {
+        Deprecation::trigger(
+            'doctrine/persistence',
+            'https://github.com/doctrine/persistence/pull/270',
+            '%s is deprecated and will be removed in 3.0',
+            __METHOD__
+        );
+
         return $this->entityClass === null;
     }
 }


### PR DESCRIPTION
Partially clearing the object manager has been deprecated, which means
these methods will become useless in 3.0