### PR TITLE
Make `*EventArgs` generic

### DIFF
--- a/src/Persistence/Event/LifecycleEventArgs.php
+++ b/src/Persistence/Event/LifecycleEventArgs.php
@@ -8,10 +8,15 @@ use Doctrine\Persistence\ObjectManager;
 /**
  * Lifecycle Events are triggered by the UnitOfWork during lifecycle transitions
  * of entities.
+ *
+ * @template TObjectManager of ObjectManager
  */
 class LifecycleEventArgs extends EventArgs
 {
-    /** @var ObjectManager */
+    /**
+     * @var ObjectManager
+     * @psalm-var TObjectManager
+     */
     private $objectManager;
 
     /** @var object */
@@ -19,6 +24,7 @@ class LifecycleEventArgs extends EventArgs
 
     /**
      * @param object $object
+     * @psalm-param TObjectManager $objectManager
      */
     public function __construct($object, ObjectManager $objectManager)
     {
@@ -52,6 +58,7 @@ class LifecycleEventArgs extends EventArgs
      * Retrieves the associated ObjectManager.
      *
      * @return ObjectManager
+     * @psalm-return TObjectManager
      */
     public function getObjectManager()
     {

--- a/src/Persistence/Event/LoadClassMetadataEventArgs.php
+++ b/src/Persistence/Event/LoadClassMetadataEventArgs.php
@@ -8,20 +8,27 @@ use Doctrine\Persistence\ObjectManager;
 
 /**
  * Class that holds event arguments for a loadMetadata event.
+ *
+ * @template TClassMetadata of ClassMetadata<object>
+ * @template TObjectManager of ObjectManager
  */
 class LoadClassMetadataEventArgs extends EventArgs
 {
     /**
      * @var ClassMetadata
-     * @psalm-var ClassMetadata<object>
+     * @psalm-var TClassMetadata
      */
     private $classMetadata;
 
-    /** @var ObjectManager */
+    /**
+     * @var ObjectManager
+     * @psalm-var TObjectManager
+     */
     private $objectManager;
 
     /**
-     * @psalm-param ClassMetadata<object> $classMetadata
+     * @psalm-param TClassMetadata $classMetadata
+     * @psalm-param TObjectManager $objectManager
      */
     public function __construct(ClassMetadata $classMetadata, ObjectManager $objectManager)
     {
@@ -33,7 +40,7 @@ class LoadClassMetadataEventArgs extends EventArgs
      * Retrieves the associated ClassMetadata.
      *
      * @return ClassMetadata
-     * @psalm-return ClassMetadata<object>
+     * @psalm-return TClassMetadata
      */
     public function getClassMetadata()
     {
@@ -43,7 +50,7 @@ class LoadClassMetadataEventArgs extends EventArgs
     /**
      * Retrieves the associated ObjectManager.
      *
-     * @return ObjectManager
+     * @return TObjectManager
      */
     public function getObjectManager()
     {

--- a/src/Persistence/Event/ManagerEventArgs.php
+++ b/src/Persistence/Event/ManagerEventArgs.php
@@ -7,12 +7,20 @@ use Doctrine\Persistence\ObjectManager;
 
 /**
  * Provides event arguments for the preFlush event.
+ *
+ * @template TObjectManager of ObjectManager
  */
 class ManagerEventArgs extends EventArgs
 {
-    /** @var ObjectManager */
+    /**
+     * @var ObjectManager
+     * @psalm-var TObjectManager
+     */
     private $objectManager;
 
+    /**
+     * @psalm-param TObjectManager $objectManager
+     */
     public function __construct(ObjectManager $objectManager)
     {
         $this->objectManager = $objectManager;
@@ -22,6 +30,7 @@ class ManagerEventArgs extends EventArgs
      * Retrieves the associated ObjectManager.
      *
      * @return ObjectManager
+     * @psalm-return TObjectManager
      */
     public function getObjectManager()
     {

--- a/src/Persistence/Event/OnClearEventArgs.php
+++ b/src/Persistence/Event/OnClearEventArgs.php
@@ -10,10 +10,15 @@ use function func_num_args;
 
 /**
  * Provides event arguments for the onClear event.
+ *
+ * @template TObjectManager of ObjectManager
  */
 class OnClearEventArgs extends EventArgs
 {
-    /** @var ObjectManager */
+    /**
+     * @var ObjectManager
+     * @psalm-var TObjectManager
+     */
     private $objectManager;
 
     /** @var string|null */
@@ -22,6 +27,7 @@ class OnClearEventArgs extends EventArgs
     /**
      * @param ObjectManager $objectManager The object manager.
      * @param string|null   $entityClass   The optional entity class.
+     * @psalm-param TObjectManager $objectManager
      */
     public function __construct($objectManager, $entityClass = null)
     {
@@ -42,6 +48,7 @@ class OnClearEventArgs extends EventArgs
      * Retrieves the associated ObjectManager.
      *
      * @return ObjectManager
+     * @psalm-return TObjectManager
      */
     public function getObjectManager()
     {

--- a/src/Persistence/Event/PreUpdateEventArgs.php
+++ b/src/Persistence/Event/PreUpdateEventArgs.php
@@ -10,6 +10,9 @@ use function sprintf;
 
 /**
  * Class that holds event arguments for a preUpdate event.
+ *
+ * @template TObjectManager of ObjectManager
+ * @extends LifecycleEventArgs<TObjectManager>
  */
 class PreUpdateEventArgs extends LifecycleEventArgs
 {
@@ -19,6 +22,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
     /**
      * @param object    $entity
      * @param mixed[][] $changeSet
+     * @psalm-param TObjectManager $objectManager
      */
     public function __construct($entity, ObjectManager $objectManager, array &$changeSet)
     {


### PR DESCRIPTION
Implementations of the persistence contracts usually use a more specific contract for their own `ObjectManager` implementation, like `EntityManagerInerface` for the Doctrine ORM.

This PR allows implementations to be more specific about the `ObjectManager` object returned by event objects. That in turn should help us to provide more precise types in the ORM.