### PR TITLE
Flag event templates as covariant

### DIFF
--- a/src/Persistence/Event/LifecycleEventArgs.php
+++ b/src/Persistence/Event/LifecycleEventArgs.php
@@ -9,7 +9,7 @@ use Doctrine\Persistence\ObjectManager;
  * Lifecycle Events are triggered by the UnitOfWork during lifecycle transitions
  * of entities.
  *
- * @template TObjectManager of ObjectManager
+ * @template-covariant TObjectManager of ObjectManager
  */
 class LifecycleEventArgs extends EventArgs
 {

--- a/src/Persistence/Event/LoadClassMetadataEventArgs.php
+++ b/src/Persistence/Event/LoadClassMetadataEventArgs.php
@@ -9,8 +9,8 @@ use Doctrine\Persistence\ObjectManager;
 /**
  * Class that holds event arguments for a loadMetadata event.
  *
- * @template TClassMetadata of ClassMetadata<object>
- * @template TObjectManager of ObjectManager
+ * @template-covariant TClassMetadata of ClassMetadata<object>
+ * @template-covariant TObjectManager of ObjectManager
  */
 class LoadClassMetadataEventArgs extends EventArgs
 {

--- a/src/Persistence/Event/ManagerEventArgs.php
+++ b/src/Persistence/Event/ManagerEventArgs.php
@@ -8,7 +8,7 @@ use Doctrine\Persistence\ObjectManager;
 /**
  * Provides event arguments for the preFlush event.
  *
- * @template TObjectManager of ObjectManager
+ * @template-covariant TObjectManager of ObjectManager
  */
 class ManagerEventArgs extends EventArgs
 {

--- a/src/Persistence/Event/OnClearEventArgs.php
+++ b/src/Persistence/Event/OnClearEventArgs.php
@@ -11,7 +11,7 @@ use function func_num_args;
 /**
  * Provides event arguments for the onClear event.
  *
- * @template TObjectManager of ObjectManager
+ * @template-covariant TObjectManager of ObjectManager
  */
 class OnClearEventArgs extends EventArgs
 {

--- a/src/Persistence/Event/PreUpdateEventArgs.php
+++ b/src/Persistence/Event/PreUpdateEventArgs.php
@@ -11,7 +11,7 @@ use function sprintf;
 /**
  * Class that holds event arguments for a preUpdate event.
  *
- * @template TObjectManager of ObjectManager
+ * @template-covariant TObjectManager of ObjectManager
  * @extends LifecycleEventArgs<TObjectManager>
  */
 class PreUpdateEventArgs extends LifecycleEventArgs


### PR DESCRIPTION
Discovered while attempting to merge #273 to the 3.0.x branch. We should safely be able flag all template types of the event classes as covariant.