### PR TITLE
Remove `doctrine/deprecations`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         "php": "^7.2 || ^8.0",
         "doctrine/collections": "^1.0",
         "doctrine/event-manager": "^1.0",
-        "psr/cache": "^1.0 || ^2.0 || ^3.0",
-        "doctrine/deprecations": "^0.5.3"
+        "psr/cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "composer/package-versions-deprecated": "^1.11",


### PR DESCRIPTION
In preparation of the 3.0.0 release, we should remove the `doctrine/deprecations` dependency. 3.0.0 will emit no deprecations, so we don't need to depend on that library.