### PR TITLE
Split MappingException

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,14 @@ awareness about deprecated code.
 
 # Upgrade to 2.5
 
+## Deprecated `MappingException`
+
+Referring to `Doctrine\Persistence\Mapping\MappingException` with `catch` or
+`instanceof` is deprecated in favor of
+`Doctrine\Persistence\Mapping\Exception\MappingException`.
+
+All methods inside this class are deprecated in favor of standalone exceptions.
+
 ## Deprecated `OnClearEventArgs::clearsAllEntities()` and `OnClearEventArgs::getEntityClass()`
 
 These methods only make sense when partially clearing the object manager, which

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -53,6 +53,7 @@
 
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix">
         <exclude-pattern>src/Persistence/Mapping/MappingException.php</exclude-pattern>
+        <exclude-pattern>src/Persistence/Mapping/Exception/MappingException.php</exclude-pattern>
     </rule>
 
     <rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect">

--- a/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
+++ b/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Persistence\Mapping\Driver;
 
+use Doctrine\Persistence\Mapping\Exception\PathRequiredForDriver;
 use Doctrine\Persistence\Mapping\MappingException;
 use FilesystemIterator;
 use RecursiveDirectoryIterator;
@@ -144,7 +145,7 @@ trait ColocatedMappingDriver
         }
 
         if (! $this->paths) {
-            throw MappingException::pathRequiredForDriver(static::class);
+            throw PathRequiredForDriver::create(static::class);
         }
 
         $classes       = [];

--- a/src/Persistence/Mapping/Driver/DefaultFileLocator.php
+++ b/src/Persistence/Mapping/Driver/DefaultFileLocator.php
@@ -2,7 +2,8 @@
 
 namespace Doctrine\Persistence\Mapping\Driver;
 
-use Doctrine\Persistence\Mapping\MappingException;
+use Doctrine\Persistence\Mapping\Exception\InvalidFileMappingDriverPath;
+use Doctrine\Persistence\Mapping\Exception\MappingFileNotFound;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
@@ -107,7 +108,7 @@ class DefaultFileLocator implements FileLocator
             }
         }
 
-        throw MappingException::mappingFileNotFound($className, $fileName);
+        throw MappingFileNotFound::create($className, $fileName);
     }
 
     /**
@@ -120,7 +121,7 @@ class DefaultFileLocator implements FileLocator
         if ($this->paths) {
             foreach ($this->paths as $path) {
                 if (! is_dir($path)) {
-                    throw MappingException::fileMappingDriversRequireConfiguredDirectoryPath($path);
+                    throw InvalidFileMappingDriverPath::create($path);
                 }
 
                 $iterator = new RecursiveIteratorIterator(

--- a/src/Persistence/Mapping/Driver/FileDriver.php
+++ b/src/Persistence/Mapping/Driver/FileDriver.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Persistence\Mapping\Driver;
 
 use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\Exception\InvalidMappingFile;
 use Doctrine\Persistence\Mapping\MappingException;
 
 use function array_keys;
@@ -97,7 +98,10 @@ abstract class FileDriver implements MappingDriver
 
         $result = $this->loadMappingFile($this->locator->findMappingFile($className));
         if (! isset($result[$className])) {
-            throw MappingException::invalidMappingFile($className, str_replace('\\', '.', $className) . $this->locator->getFileExtension());
+            throw InvalidMappingFile::create(
+                $className,
+                str_replace('\\', '.', $className) . $this->locator->getFileExtension()
+            );
         }
 
         $this->classCache[$className] = $result[$className];

--- a/src/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/src/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Persistence\Mapping\Driver;
 
 use Doctrine\Persistence\Mapping\ClassMetadata;
-use Doctrine\Persistence\Mapping\MappingException;
+use Doctrine\Persistence\Mapping\Exception\ClassNotFoundInNamespaces;
 
 use function array_keys;
 use function assert;
@@ -88,7 +88,7 @@ class MappingDriverChain implements MappingDriver
             return;
         }
 
-        throw MappingException::classNotFoundInNamespaces($className, array_keys($this->drivers));
+        throw ClassNotFoundInNamespaces::create($className, array_keys($this->drivers));
     }
 
     /**

--- a/src/Persistence/Mapping/Driver/StaticPHPDriver.php
+++ b/src/Persistence/Mapping/Driver/StaticPHPDriver.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Persistence\Mapping\Driver;
 
 use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\Exception\PathRequiredForDriver;
 use Doctrine\Persistence\Mapping\MappingException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -78,7 +79,7 @@ class StaticPHPDriver implements MappingDriver
         }
 
         if (! $this->paths) {
-            throw MappingException::pathRequiredForDriver(static::class);
+            throw PathRequiredForDriver::create(static::class);
         }
 
         $classes       = [];

--- a/src/Persistence/Mapping/Driver/SymfonyFileLocator.php
+++ b/src/Persistence/Mapping/Driver/SymfonyFileLocator.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Persistence\Mapping\Driver;
 
+use Doctrine\Persistence\Mapping\Exception\MappingFileNotFound;
 use Doctrine\Persistence\Mapping\MappingException;
 use InvalidArgumentException;
 use RecursiveDirectoryIterator;
@@ -236,6 +237,9 @@ class SymfonyFileLocator implements FileLocator
             }
         }
 
-        throw MappingException::mappingFileNotFound($className, substr($className, (int) strrpos($className, '\\') + 1) . $this->fileExtension);
+        throw MappingFileNotFound::create(
+            $className,
+            substr($className, (int) strrpos($className, '\\') + 1) . $this->fileExtension
+        );
     }
 }

--- a/src/Persistence/Mapping/Exception/ClassNotFoundInNamespaces.php
+++ b/src/Persistence/Mapping/Exception/ClassNotFoundInNamespaces.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Persistence\Mapping\Exception;
+
+use function implode;
+use function sprintf;
+
+final class ClassNotFoundInNamespaces extends MappingException
+{
+    /**
+     * @param class-string $className
+     * @param string[]     $namespaces
+     */
+    public static function create(string $className, array $namespaces): self
+    {
+        return new self(sprintf(
+            'The class "%s" was not found in the chain of configured namespaces %s',
+            $className,
+            implode(', ', $namespaces)
+        ));
+    }
+}

--- a/src/Persistence/Mapping/Exception/InvalidFileMappingDriverPath.php
+++ b/src/Persistence/Mapping/Exception/InvalidFileMappingDriverPath.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Persistence\Mapping\Exception;
+
+use function sprintf;
+
+final class InvalidFileMappingDriverPath extends MappingException
+{
+    public static function create(?string $path = null): self
+    {
+        if (! empty($path)) {
+            $path = '[' . $path . ']';
+        }
+
+        return new self(sprintf(
+            'File mapping drivers must have a valid directory path, ' .
+            'however the given path %s seems to be incorrect!',
+            (string) $path
+        ));
+    }
+}

--- a/src/Persistence/Mapping/Exception/InvalidMappingFile.php
+++ b/src/Persistence/Mapping/Exception/InvalidMappingFile.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Persistence\Mapping\Exception;
+
+use function sprintf;
+
+final class InvalidMappingFile extends MappingException
+{
+    public static function create(string $entityName, string $fileName): self
+    {
+        return new self(sprintf(
+            'Invalid mapping file "%s" for class "%s".',
+            $fileName,
+            $entityName
+        ));
+    }
+}

--- a/src/Persistence/Mapping/Exception/MappingException.php
+++ b/src/Persistence/Mapping/Exception/MappingException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\Persistence\Mapping\Exception;
+
+use Doctrine\Persistence\Mapping\MappingException as LegacyMappingException;
+
+/**
+ * Will become an interface in 3.0.
+ * Do not extend or instantiate this class outside this package.
+ */
+class MappingException extends LegacyMappingException
+{
+}

--- a/src/Persistence/Mapping/Exception/MappingFileNotFound.php
+++ b/src/Persistence/Mapping/Exception/MappingFileNotFound.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Persistence\Mapping\Exception;
+
+use function sprintf;
+
+final class MappingFileNotFound extends MappingException
+{
+    public static function create(string $entityName, string $fileName): self
+    {
+        return new self(sprintf(
+            'No mapping file found named "%s" for class "%s".',
+            $fileName,
+            $entityName
+        ));
+    }
+}

--- a/src/Persistence/Mapping/Exception/NonExistingClass.php
+++ b/src/Persistence/Mapping/Exception/NonExistingClass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Persistence\Mapping\Exception;
+
+use function sprintf;
+
+final class NonExistingClass extends MappingException
+{
+    public static function create(string $className): self
+    {
+        return new self(sprintf('Class "%s" does not exist', $className));
+    }
+}

--- a/src/Persistence/Mapping/Exception/PathRequiredForDriver.php
+++ b/src/Persistence/Mapping/Exception/PathRequiredForDriver.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Persistence\Mapping\Exception;
+
+use function sprintf;
+
+final class PathRequiredForDriver extends MappingException
+{
+    /**
+     * @param class-string $driverClassName
+     */
+    public static function create(string $driverClassName): self
+    {
+        return new self(sprintf(
+            'Specifying the paths to your entities is required when using "%s" to retrieve all class names.',
+            $driverClassName
+        ));
+    }
+}

--- a/src/Persistence/Mapping/MappingException.php
+++ b/src/Persistence/Mapping/MappingException.php
@@ -9,10 +9,14 @@ use function sprintf;
 
 /**
  * A MappingException indicates that something is wrong with the mapping setup.
+ *
+ * @deprecated use Doctrine\Persistence\Mapping\Exception\MappingException for catch and instanceof
  */
 class MappingException extends Exception
 {
     /**
+     * @deprecated use ClassNotFoundInNamespaces
+     *
      * @param string   $className
      * @param string[] $namespaces
      *
@@ -39,6 +43,8 @@ class MappingException extends Exception
     }
 
     /**
+     * @deprecated Use PathRequiredForDriver instead
+     *
      * @param class-string $driverClassName
      */
     public static function pathRequiredForDriver(string $driverClassName): self
@@ -50,6 +56,8 @@ class MappingException extends Exception
     }
 
     /**
+     * @deprecated use InvalidFileMappingDriverPath instead
+     *
      * @param string|null $path
      *
      * @return self
@@ -68,6 +76,8 @@ class MappingException extends Exception
     }
 
     /**
+     * @deprecated use MappingFileNotFound instead
+     *
      * @param string $entityName
      * @param string $fileName
      *
@@ -83,6 +93,8 @@ class MappingException extends Exception
     }
 
     /**
+     * @deprecated use InvalidMappingFile instead
+     *
      * @param string $entityName
      * @param string $fileName
      *
@@ -98,6 +110,8 @@ class MappingException extends Exception
     }
 
     /**
+     * @deprecated use NonExistingClass instead
+     *
      * @param string $className
      *
      * @return self

--- a/src/Persistence/Mapping/RuntimeReflectionService.php
+++ b/src/Persistence/Mapping/RuntimeReflectionService.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Persistence\Mapping;
 
+use Doctrine\Persistence\Mapping\Exception\NonExistingClass;
 use Doctrine\Persistence\Reflection\RuntimePublicReflectionProperty;
 use Doctrine\Persistence\Reflection\TypedNoDefaultReflectionProperty;
 use Doctrine\Persistence\Reflection\TypedNoDefaultRuntimePublicReflectionProperty;
@@ -36,7 +37,7 @@ class RuntimeReflectionService implements ReflectionService
     public function getParentClasses($class)
     {
         if (! class_exists($class)) {
-            throw MappingException::nonExistingClass($class);
+            throw NonExistingClass::create($class);
         }
 
         $parents = class_parents($class);

--- a/tests/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -136,7 +136,7 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
 
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage(
-            'Class \'Doctrine\Tests\Persistence\Mapping\ChildEntity:Foo\' does not exist'
+            'Class "Doctrine\Tests\Persistence\Mapping\ChildEntity:Foo" does not exist'
         );
 
         $this->cmf->getMetadataFor('prefix:ChildEntity:Foo');

--- a/tests/Persistence/Mapping/DefaultFileLocatorTest.php
+++ b/tests/Persistence/Mapping/DefaultFileLocatorTest.php
@@ -55,7 +55,7 @@ class DefaultFileLocatorTest extends DoctrineTestCase
         $locator = new DefaultFileLocator([$path], '.yml');
 
         $this->expectException(MappingException::class);
-        $this->expectExceptionMessage("No mapping file found named 'stdClass2.yml' for class 'stdClass2'");
+        $this->expectExceptionMessage('No mapping file found named "stdClass2.yml" for class "stdClass2"');
         $locator->findMappingFile('stdClass2');
     }
 

--- a/tests/Persistence/Mapping/SymfonyFileLocatorTest.php
+++ b/tests/Persistence/Mapping/SymfonyFileLocatorTest.php
@@ -184,7 +184,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $locator = new SymfonyFileLocator([$path => $prefix], '.yml');
 
         $this->expectException(MappingException::class);
-        $this->expectExceptionMessage("No mapping file found named 'stdClass2.yml' for class 'Foo\stdClass2'.");
+        $this->expectExceptionMessage('No mapping file found named "stdClass2.yml" for class "Foo\stdClass2".');
         $locator->findMappingFile('Foo\\stdClass2');
     }
 


### PR DESCRIPTION
This will allow us to make the MappingException class an interface in
3.0. Additionally, it allows client code to catch exceptions more
precisely, and makes room for extra named constructors.

Prompted by https://github.com/doctrine/orm/pull/7199#issuecomment-1097249126