### PR TITLE
Fix broken mock

### DIFF
--- a/tests/Persistence/Mapping/AbstractClassMetadataFactoryTest.php
+++ b/tests/Persistence/Mapping/AbstractClassMetadataFactoryTest.php
@@ -72,13 +72,17 @@ final class AbstractClassMetadataFactoryTest extends DoctrineTestCase
 
     public function testAnonymousClassIsNotMistakenForShortAlias(): void
     {
+        $driverMock = $this->createMock(MappingDriver::class);
+        $driverMock->expects(self::once())->method('isTransient')->willReturn(false);
         $cmf = $this->getMockForAbstractClass(AbstractClassMetadataFactory::class);
-        $cmf->method('getDriver')->willReturn($this->createMock(MappingDriver::class));
+        $cmf->method('getDriver')->willReturn($driverMock);
+
         $this->expectNoDeprecationWithIdentifier(
             'https://github.com/doctrine/persistence/issues/204'
         );
-        $cmf->isTransient(get_class(new class () {
-        }));
+
+        self::assertFalse($cmf->isTransient(get_class(new class () {
+        })));
     }
 }
 


### PR DESCRIPTION
This test introduced with #286 does not test if the `isTransient()` call is actually delegated to the driver. In addition, the called `isTransient()` method currently returns `null` which violates the interface and will become a problem if we were to add native return types one fine day.