### PR TITLE
Declare ObjectRepository's template as covariant

### DIFF
--- a/src/Persistence/ObjectRepository.php
+++ b/src/Persistence/ObjectRepository.php
@@ -7,7 +7,7 @@ use UnexpectedValueException;
 /**
  * Contract for a Doctrine persistence layer ObjectRepository class to implement.
  *
- * @template T of object
+ * @template-covariant T of object
  */
 interface ObjectRepository
 {


### PR DESCRIPTION
The `ObjectRepository` interface is documented as generic with a template variable `T`. Since `T` is only used in return types, we can safely assume that any piece of code that expects an `ObjectRepository<ParentClass>` can safely operate on an `ObjectRepository<ChildClass>` (given `ChildClass extends ParentClass` of course).

This is why I'd like to declare the template variable as covariant.