### PR TITLE
 Fix AbstractManagerRegistry::getManagerForClass when proxy class is used.

### DIFF
--- a/src/Persistence/AbstractManagerRegistry.php
+++ b/src/Persistence/AbstractManagerRegistry.php
@@ -173,6 +173,8 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
             return null;
         }
 
+        $className = $proxyClass->getName();
+
         if ($proxyClass->implementsInterface($this->proxyInterfaceName)) {
             $parentClass = $proxyClass->getParentClass();
 
@@ -186,7 +188,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
         foreach ($this->managers as $id) {
             $manager = $this->getService($id);
 
-            if (! $manager->getMetadataFactory()->isTransient($class)) {
+            if (! $manager->getMetadataFactory()->isTransient($className)) {
                 return $manager;
             }
         }


### PR DESCRIPTION
Fixes: https://github.com/doctrine/persistence/issues/293

This PR passes the correct class name to the Metadata Factory `isTransient` method whether the original class is a proxy class or a real class. Whenever a proxy class is the original class, `isTransient` will get the parent class name and whenever a real class is the original class, `isTransient` will get the real class name.