### PR TITLE
Throw an exception when passing an entity alias

### DIFF
--- a/tests/Persistence/Mapping/AbstractClassMetadataFactoryTest.php
+++ b/tests/Persistence/Mapping/AbstractClassMetadataFactoryTest.php
@@ -49,13 +49,34 @@ final class AbstractClassMetadataFactoryTest extends DoctrineTestCase
 
     public function testAnonymousClassIsNotMistakenForShortAlias(): void
     {
-        $driverMock = $this->createMock(MappingDriver::class);
-        $driverMock->expects(self::once())->method('isTransient')->willReturn(false);
         $cmf = $this->getMockForAbstractClass(AbstractClassMetadataFactory::class);
-        $cmf->method('getDriver')->willReturn($driverMock);
 
         self::assertFalse($cmf->isTransient(get_class(new class () {
         })));
+    }
+
+    public function testItThrowsWhenAttemptingToGetMetadataForShortAlias(): void
+    {
+        $cmf = $this->getMockForAbstractClass(AbstractClassMetadataFactory::class);
+        $this->expectException(MappingException::class);
+        /**
+         * @psalm-suppress ArgumentTypeCoercion
+         * @psalm-suppress UndefinedClass
+         */
+        // @phpstan-ignore-next-line
+        $cmf->getMetadataFor('App:Test');
+    }
+
+    public function testItThrowsWhenAttemptingToCheckTransientForShortAlias(): void
+    {
+        $cmf = $this->getMockForAbstractClass(AbstractClassMetadataFactory::class);
+        $this->expectException(MappingException::class);
+        /**
+         * @psalm-suppress ArgumentTypeCoercion
+         * @psalm-suppress UndefinedClass
+         */
+        // @phpstan-ignore-next-line
+        $cmf->isTransient('App:Test');
     }
 }
 


### PR DESCRIPTION
Many users have missed the deprecation about using an entity alias when they migrated to doctrine/persistence 3.
Passing an entity alias was triggering a weird error due to generating an invalid PSR-6 cache key due to `:` being a reserved keyword. So this adds a dedicated check reporting that it is an invalid class name instead.