### PR TITLE
Drop doctrine/collections dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "doctrine/collections": "^1.0",
         "doctrine/event-manager": "^1.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0"
     },


### PR DESCRIPTION
The only feature that actually interacted with the doctrine/collections library was the `PersistentObject` which we've removed in 3.0. It does not make sense to keep that dependency then.