### PR TITLE
fix: Backport Normalize class names #300 (#301)

### DIFF
--- a/src/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/src/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -21,6 +21,7 @@ use function assert;
 use function class_exists;
 use function explode;
 use function is_array;
+use function ltrim;
 use function str_replace;
 use function strpos;
 use function strrpos;
@@ -215,6 +216,18 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     abstract protected function isEntity(ClassMetadata $class);
 
     /**
+     * Removes the prepended backslash of a class string to conform with how php outputs class names
+     *
+     * @param string $className
+     *
+     * @return string
+     */
+    private function normalizeClassName($className)
+    {
+        return ltrim($className, '\\');
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @throws ReflectionException
@@ -222,6 +235,8 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      */
     public function getMetadataFor($className)
     {
+        $className = $this->normalizeClassName($className);
+
         if (isset($this->loadedMetadata[$className])) {
             return $this->loadedMetadata[$className];
         }
@@ -307,6 +322,8 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      */
     public function hasMetadataFor($className)
     {
+        $className = $this->normalizeClassName($className);
+
         return isset($this->loadedMetadata[$className]);
     }
 
@@ -321,7 +338,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      */
     public function setMetadataFor($className, $class)
     {
-        $this->loadedMetadata[$className] = $class;
+        $this->loadedMetadata[$this->normalizeClassName($className)] = $class;
     }
 
     /**

--- a/tests/Persistence/Mapping/AbstractClassMetadataFactoryTest.php
+++ b/tests/Persistence/Mapping/AbstractClassMetadataFactoryTest.php
@@ -84,6 +84,19 @@ final class AbstractClassMetadataFactoryTest extends DoctrineTestCase
         self::assertFalse($cmf->isTransient(get_class(new class () {
         })));
     }
+
+    public function testItGetsTheSameMetadataForBackslashedClassName(): void
+    {
+        $cmf = $this->getMockForAbstractClass(AbstractClassMetadataFactory::class);
+        $cmf
+            ->method('newClassMetadataInstance')
+            ->with(SomeOtherEntity::class)
+            ->willReturn(
+                $this->createMock(ClassMetadata::class)
+            );
+
+        self::assertSame($cmf->getMetadataFor(SomeOtherEntity::class), $cmf->getMetadataFor('\\' . SomeOtherEntity::class));
+    }
 }
 
 class SomeGrandParentEntity
@@ -95,5 +108,9 @@ class SomeParentEntity extends SomeGrandParentEntity
 }
 
 final class SomeEntity extends SomeParentEntity
+{
+}
+
+final class SomeOtherEntity
 {
 }


### PR DESCRIPTION
Backport class name normalization to 2.5.x