### PR TITLE
Add Proxy::__setInitialized() and RuntimeReflectionProperty

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,17 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
+# Upgrade to 3.1
+
+## Added method `Proxy::__setInitialized()`
+
+Classes implementing `Doctrine\Persistence\Proxy` should implement the new
+method. This method will be added to the interface in 4.0.
+
+## Deprecated `RuntimePublicReflectionProperty`
+
+Use `RuntimeReflectionProperty` instead.
+
 # Upgrade to 3.0
 
 ## Removed `OnClearEventArgs::clearsAllEntities()` and `OnClearEventArgs::getEntityClass()`

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,11 @@ parameters:
 			path: src/Persistence/Reflection/EnumReflectionProperty.php
 
 		-
+			message: "#^Call to function method_exists\\(\\) with Doctrine\\\\Persistence\\\\Proxy and '__setInitialized' will always evaluate to true\\.$#"
+			count: 1
+			path: src/Persistence/Reflection/RuntimeReflectionProperty.php
+
+		-
 			message: "#^Variable property access on \\$this\\(Doctrine\\\\Persistence\\\\Reflection\\\\TypedNoDefaultRuntimePublicReflectionProperty\\)\\.$#"
 			count: 1
 			path: src/Persistence/Reflection/TypedNoDefaultRuntimePublicReflectionProperty.php
@@ -74,6 +79,16 @@ parameters:
 			message: "#^Property Doctrine\\\\Tests\\\\Persistence\\\\RuntimePublicReflectionPropertyTestProxyMock\\:\\:\\$checkedProperty \\(string\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: tests/Persistence/RuntimePublicReflectionPropertyTest.php
+
+		-
+			message: "#^Method Doctrine\\\\Tests\\\\Persistence\\\\RuntimeReflectionPropertyTestProxyMock\\:\\:__setInitialized\\(\\) has parameter \\$initialized with no type specified\\.$#"
+			count: 1
+			path: tests/Persistence/RuntimeReflectionPropertyTest.php
+
+		-
+			message: "#^Property Doctrine\\\\Tests\\\\Persistence\\\\RuntimeReflectionPropertyTestProxyMock\\:\\:\\$checkedProperty \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: tests/Persistence/RuntimeReflectionPropertyTest.php
 
 		-
 			message: "#^Property Doctrine\\\\Tests_PHP74\\\\Persistence\\\\Mapping\\\\RuntimeReflectionServiceTest\\:\\:\\$nonTypedDefaultProperty is never read, only written\\.$#"

--- a/psalm.xml
+++ b/psalm.xml
@@ -27,6 +27,7 @@
         </TypeDoesNotContainType>
         <NullArgument>
             <errorLevel type="suppress">
+                <file name="src/Persistence/Reflection/RuntimeReflectionProperty.php"/>
                 <file name="tests/Persistence/Mapping/SymfonyFileLocatorTest.php"/>
             </errorLevel>
         </NullArgument>

--- a/src/Persistence/Mapping/RuntimeReflectionService.php
+++ b/src/Persistence/Mapping/RuntimeReflectionService.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\Persistence\Mapping;
 
-use Doctrine\Persistence\Reflection\RuntimePublicReflectionProperty;
+use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
 use Doctrine\Persistence\Reflection\TypedNoDefaultReflectionProperty;
-use Doctrine\Persistence\Reflection\TypedNoDefaultRuntimePublicReflectionProperty;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionMethod;
-use ReflectionProperty;
 
 use function array_key_exists;
 use function assert;
@@ -86,16 +84,10 @@ class RuntimeReflectionService implements ReflectionService
      */
     public function getAccessibleProperty(string $class, string $property)
     {
-        $reflectionProperty = new ReflectionProperty($class, $property);
+        $reflectionProperty = new RuntimeReflectionProperty($class, $property);
 
         if ($this->supportsTypedPropertiesWorkaround && ! array_key_exists($property, $this->getClass($class)->getDefaultProperties())) {
-            if ($reflectionProperty->isPublic()) {
-                $reflectionProperty = new TypedNoDefaultRuntimePublicReflectionProperty($class, $property);
-            } else {
-                $reflectionProperty = new TypedNoDefaultReflectionProperty($class, $property);
-            }
-        } elseif ($reflectionProperty->isPublic()) {
-            $reflectionProperty = new RuntimePublicReflectionProperty($class, $property);
+            $reflectionProperty = new TypedNoDefaultReflectionProperty($class, $property);
         }
 
         $reflectionProperty->setAccessible(true);

--- a/src/Persistence/Proxy.php
+++ b/src/Persistence/Proxy.php
@@ -8,6 +8,7 @@ namespace Doctrine\Persistence;
  * Interface for proxy classes.
  *
  * @template T of object
+ * @method void __setInitialized(bool $initialized) Implementing this method will be mandatory in version 4.
  */
 interface Proxy
 {

--- a/src/Persistence/Reflection/RuntimePublicReflectionProperty.php
+++ b/src/Persistence/Reflection/RuntimePublicReflectionProperty.php
@@ -10,6 +10,8 @@ use ReturnTypeWillChange;
 
 /**
  * PHP Runtime Reflection Public Property - special overrides for public properties.
+ *
+ * @deprecated since version 3.1, use RuntimeReflectionProperty instead.
  */
 class RuntimePublicReflectionProperty extends ReflectionProperty
 {

--- a/src/Persistence/Reflection/RuntimeReflectionProperty.php
+++ b/src/Persistence/Reflection/RuntimeReflectionProperty.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Persistence\Reflection;
+
+use Doctrine\Common\Proxy\Proxy as CommonProxy;
+use Doctrine\Persistence\Proxy;
+use ReflectionProperty;
+use ReturnTypeWillChange;
+
+use function method_exists;
+
+/**
+ * PHP Runtime Reflection Property.
+ *
+ * Avoids triggering lazy loading if the provided object
+ * is a {@see \Doctrine\Persistence\Proxy}.
+ */
+class RuntimeReflectionProperty extends ReflectionProperty
+{
+    /** @var string */
+    private $key;
+
+    public function __construct(string $class, string $name)
+    {
+        parent::__construct($class, $name);
+        $this->key = $this->isPrivate() ? "\0" . $class . "\0" . $name : ($this->isProtected() ? "\0*\0" . $name : $name);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return mixed
+     */
+    #[ReturnTypeWillChange]
+    public function getValue($object = null)
+    {
+        if ($object === null) {
+            return parent::getValue($object);
+        }
+
+        return ((array) $object)[$this->key] ?? null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param object|null $object
+     * @param mixed       $value
+     *
+     * @return void
+     */
+    #[ReturnTypeWillChange]
+    public function setValue($object, $value = null)
+    {
+        if (! ($object instanceof Proxy && ! $object->__isInitialized())) {
+            parent::setValue($object, $value);
+
+            return;
+        }
+
+        if ($object instanceof CommonProxy) {
+            $originalInitializer = $object->__getInitializer();
+            $object->__setInitializer(null);
+            parent::setValue($object, $value);
+            $object->__setInitializer($originalInitializer);
+
+            return;
+        }
+
+        if (! method_exists($object, '__setInitialized')) {
+            return;
+        }
+
+        $object->__setInitialized(true);
+        parent::setValue($object, $value);
+        $object->__setInitialized(false);
+    }
+}

--- a/src/Persistence/Reflection/TypedNoDefaultReflectionProperty.php
+++ b/src/Persistence/Reflection/TypedNoDefaultReflectionProperty.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\Persistence\Reflection;
 
-use ReflectionProperty;
-
 /**
  * PHP Typed No Default Reflection Property - special override for typed properties without a default value.
  */
-class TypedNoDefaultReflectionProperty extends ReflectionProperty
+class TypedNoDefaultReflectionProperty extends RuntimeReflectionProperty
 {
     use TypedNoDefaultReflectionPropertyBase;
 }

--- a/src/Persistence/Reflection/TypedNoDefaultReflectionPropertyBase.php
+++ b/src/Persistence/Reflection/TypedNoDefaultReflectionPropertyBase.php
@@ -11,6 +11,8 @@ use function assert;
 
 /**
  * PHP Typed No Default Reflection Property Base - special override for typed properties without a default value.
+ *
+ * @internal since version 3.1
  */
 trait TypedNoDefaultReflectionPropertyBase
 {

--- a/src/Persistence/Reflection/TypedNoDefaultRuntimePublicReflectionProperty.php
+++ b/src/Persistence/Reflection/TypedNoDefaultRuntimePublicReflectionProperty.php
@@ -6,6 +6,8 @@ namespace Doctrine\Persistence\Reflection;
 
 /**
  * PHP Typed No Default Runtime Public Reflection Property - special override for public typed properties without a default value.
+ *
+ * @deprecated since version 3.1, use TypedNoDefaultReflectionProperty instead.
  */
 class TypedNoDefaultRuntimePublicReflectionProperty extends RuntimePublicReflectionProperty
 {

--- a/tests/Persistence/Mapping/RuntimeReflectionServiceTest.php
+++ b/tests/Persistence/Mapping/RuntimeReflectionServiceTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\Persistence\Mapping;
 
 use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
-use Doctrine\Persistence\Reflection\RuntimePublicReflectionProperty;
+use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -63,6 +63,6 @@ class RuntimeReflectionServiceTest extends TestCase
         self::assertInstanceOf(RuntimeReflectionService::class, $reflProp->getValue($this));
 
         $reflProp = $this->reflectionService->getAccessibleProperty(self::class, 'unusedPublicProperty');
-        self::assertInstanceOf(RuntimePublicReflectionProperty::class, $reflProp);
+        self::assertInstanceOf(RuntimeReflectionProperty::class, $reflProp);
     }
 }

--- a/tests/Persistence/RuntimeReflectionPropertyTest.php
+++ b/tests/Persistence/RuntimeReflectionPropertyTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Persistence;
+
+use Closure;
+use Doctrine\Common\Proxy\Proxy as CommonProxy;
+use Doctrine\Persistence\Proxy;
+use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+
+class DummyMock
+{
+    public function callGet(): void
+    {
+    }
+
+    public function callSet(): void
+    {
+    }
+}
+
+class RuntimeReflectionPropertyTest extends TestCase
+{
+    /**
+     * @testWith ["test", "testValue"]
+     *           ["privateTest", "privateTestValue"]
+     */
+    public function testGetSetValue(string $name, string $value): void
+    {
+        $object = new RuntimeReflectionPropertyTestClass();
+
+        $reflProperty = new RuntimeReflectionProperty(RuntimeReflectionPropertyTestClass::class, $name);
+
+        self::assertSame($value, $reflProperty->getValue($object));
+
+        $reflProperty->setValue($object, 'changedValue');
+
+        self::assertSame('changedValue', $reflProperty->getValue($object));
+    }
+
+    /**
+     * @param class-string<RuntimeReflectionPropertyTestProxyMock> $proxyClass
+     *
+     * @testWith ["Doctrine\\Tests\\Persistence\\RuntimeReflectionPropertyTestProxyMock"]
+     *           ["Doctrine\\Tests\\Persistence\\RuntimeReflectionPropertyTestCommonProxyMock"]
+     */
+    public function testGetValueOnProxyProperty(string $proxyClass): void
+    {
+        $getCheckMock = $this->createMock(DummyMock::class);
+        $getCheckMock->expects(self::never())->method('callGet');
+        $initializer = static function () use ($getCheckMock): void {
+            $getCheckMock->callGet();
+        };
+
+        $mockProxy = new $proxyClass($initializer);
+
+        $reflProperty = new RuntimeReflectionProperty($proxyClass, 'checkedProperty');
+
+        self::assertSame('testValue', $reflProperty->getValue($mockProxy));
+        unset($mockProxy->checkedProperty);
+        self::assertNull($reflProperty->getValue($mockProxy));
+    }
+
+    /**
+     * @param class-string<RuntimeReflectionPropertyTestProxyMock> $proxyClass
+     *
+     * @testWith ["Doctrine\\Tests\\Persistence\\RuntimeReflectionPropertyTestProxyMock"]
+     *           ["Doctrine\\Tests\\Persistence\\RuntimeReflectionPropertyTestCommonProxyMock"]
+     */
+    public function testSetValueOnProxyProperty(string $proxyClass): void
+    {
+        $setCheckMock = $this->createMock(DummyMock::class);
+        $setCheckMock->expects(self::never())->method('callSet');
+        $initializer = static function () use ($setCheckMock): void {
+            $setCheckMock->callSet();
+        };
+
+        $mockProxy = new $proxyClass($initializer);
+
+        $reflProperty = new RuntimeReflectionProperty($proxyClass, 'checkedProperty');
+
+        $reflProperty->setValue($mockProxy, 'newValue');
+        self::assertSame('newValue', $mockProxy->checkedProperty);
+
+        unset($mockProxy->checkedProperty);
+        $reflProperty->setValue($mockProxy, 'otherNewValue');
+        self::assertSame('otherNewValue', $mockProxy->checkedProperty);
+
+        if (! $mockProxy instanceof CommonProxy) {
+            return;
+        }
+
+        $setCheckMock = $this->createMock(DummyMock::class);
+        $setCheckMock->expects(self::once())->method('callSet');
+        $initializer = static function () use ($setCheckMock): void {
+            $setCheckMock->callSet();
+        };
+
+        $mockProxy->__setInitializer($initializer);
+        $mockProxy->__setInitialized(true);
+
+        unset($mockProxy->checkedProperty);
+        $reflProperty->setValue($mockProxy, 'againNewValue');
+        self::assertSame('againNewValue', $mockProxy->checkedProperty);
+    }
+}
+
+/**
+ * Mock that simulates proxy property lazy loading
+ *
+ * @implements Proxy<object>
+ */
+class RuntimeReflectionPropertyTestProxyMock implements Proxy
+{
+    /** @var Closure|null */
+    protected $initializer = null;
+
+    /** @var bool */
+    private $initialized = false;
+
+    /** @var string */
+    public $checkedProperty = 'testValue';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct(?Closure $initializer = null)
+    {
+        $this->initializer = $initializer;
+    }
+
+    public function __load(): void
+    {
+    }
+
+    public function __isInitialized(): bool
+    {
+        return $this->initialized;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __setInitialized($initialized): void
+    {
+        $this->initialized = $initialized;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function __get(string $name)
+    {
+        if (! $this->initialized && $this->initializer !== null) {
+            ($this->initializer)();
+        }
+
+        return $this->checkedProperty;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function __set(string $name, $value): void
+    {
+        if (! $this->initialized && $this->initializer !== null) {
+            ($this->initializer)();
+        }
+
+        $this->checkedProperty = $value;
+    }
+
+    public function __isset(string $name): bool
+    {
+        if (! $this->initialized && $this->initializer !== null) {
+            ($this->initializer)();
+        }
+
+        return isset($this->checkedProperty);
+    }
+}
+/**
+ * Mock that simulates proxy property lazy loading
+ *
+ * @implements CommonProxy<object>
+ */
+class RuntimeReflectionPropertyTestCommonProxyMock extends RuntimeReflectionPropertyTestProxyMock implements CommonProxy
+{
+    /**
+     * @param mixed $value
+     */
+    public function __set(string $name, $value): void
+    {
+        if ($this->initializer !== null) {
+            ($this->initializer)();
+        }
+
+        $this->checkedProperty = $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __getInitializer()
+    {
+        return $this->initializer;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __setInitializer(?Closure $initializer = null)
+    {
+        $this->initializer = $initializer;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return mixed[] Keys are the property names, and values are the default
+     *                 values for those properties.
+     * @phpstan-return array<string, mixed>
+     */
+    public function __getLazyProperties()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __setCloner(?Closure $cloner = null)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __getCloner()
+    {
+        throw new LogicException('Not implemented');
+    }
+}
+
+class RuntimeReflectionPropertyTestClass
+{
+    /** @var string|null */
+    public $test = 'testValue';
+
+    /** @var string|null */
+    public $privateTest = 'privateTestValue';
+}

--- a/tests_php74/Persistence/Mapping/RuntimeReflectionServiceTest.php
+++ b/tests_php74/Persistence/Mapping/RuntimeReflectionServiceTest.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\Tests_PHP74\Persistence\Mapping;
 
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
-use Doctrine\Persistence\Reflection\RuntimePublicReflectionProperty;
+use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
 use Doctrine\Persistence\Reflection\TypedNoDefaultReflectionProperty;
-use Doctrine\Persistence\Reflection\TypedNoDefaultRuntimePublicReflectionProperty;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -54,8 +53,8 @@ class RuntimeReflectionServiceTest extends TestCase
     public function testGetTypedPublicNoDefaultPropertyWorksWithGetValue(): void
     {
         $reflProp = $this->reflectionService->getAccessibleProperty(self::class, 'typedNoDefaultPublicProperty');
-        self::assertInstanceOf(RuntimePublicReflectionProperty::class, $reflProp);
-        self::assertInstanceOf(TypedNoDefaultRuntimePublicReflectionProperty::class, $reflProp);
+        self::assertInstanceOf(RuntimeReflectionProperty::class, $reflProp);
+        self::assertInstanceOf(TypedNoDefaultReflectionProperty::class, $reflProp);
         self::assertNull($reflProp->getValue($this));
     }
 
@@ -82,6 +81,6 @@ class RuntimeReflectionServiceTest extends TestCase
     public function testGetNonTypedPublicDefaultPropertyWorksWithGetValue(): void
     {
         $reflProp = $this->reflectionService->getAccessibleProperty(self::class, 'nonTypedDefaultPublicProperty');
-        self::assertInstanceOf(RuntimePublicReflectionProperty::class, $reflProp);
+        self::assertInstanceOf(RuntimeReflectionProperty::class, $reflProp);
     }
 }


### PR DESCRIPTION
On the path to deprecate `Doctrine\Common\Proxy\Proxy`, I figured out that we're going to need adding `__setInitialized()` to the `Proxy` interface. This is because we need it in `RuntimeReflectionProperty` to disable lazy-loading while calling `ReflectionProperty::setValue()`.

The new `RuntimeReflectionProperty` allows getting+setting *any* properties on objects while preventing lazy-loading initialization, which is something that's going to be needed also to move to more capable proxy implementations.

`RuntimePublicReflectionProperty` is not enough and is thus deprecated.