### PR TITLE
Change access modifiers of AbstractManagerRegistry properties.

### DIFF
--- a/src/Persistence/AbstractManagerRegistry.php
+++ b/src/Persistence/AbstractManagerRegistry.php
@@ -20,10 +20,10 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     private $name;
 
     /** @var string[] */
-    private $connections;
+    protected $connections;
 
     /** @var string[] */
-    private $managers;
+    protected $managers;
 
     /** @var string */
     private $defaultConnection;


### PR DESCRIPTION
I'm integrating the doctrine ORM to our's legacy project, and I need ManagerRegistry instance.
But when I started to implement resetService() abstract method, I found than I cannot get direct access to properties which it should change without reflection. I think that private access modifiers make you use reflection, that is inappropriate in this case, because resetService() implementation should override $connections or $managers arrays of parent class to which child class do not have access.

The conclusion is: private properties that required to be modified in child implementation of abstract method seems to be a bad approach, because it breaks inheritance scope and makes developer to use reflection API.