### PR TITLE
Improve phpdoc about list

### DIFF
--- a/src/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/src/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -273,7 +273,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * @psalm-param class-string $name
      *
      * @return string[]
-     * @psalm-return class-string[]
+     * @psalm-return list<class-string>
      */
     protected function getParentClasses(string $name)
     {
@@ -305,6 +305,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * @psalm-param class-string $name
      *
      * @return array<int, string>
+     * @psalm-return list<string>
      */
     protected function loadMetadata(string $name)
     {

--- a/src/Persistence/Mapping/ClassMetadataFactory.php
+++ b/src/Persistence/Mapping/ClassMetadataFactory.php
@@ -16,7 +16,7 @@ interface ClassMetadataFactory
      * mapping driver.
      *
      * @return ClassMetadata[] The ClassMetadata instances of all mapped classes.
-     * @psalm-return T[]
+     * @psalm-return list<T>
      */
     public function getAllMetadata();
 


### PR DESCRIPTION
I got an error from phpstan for the following code
```
$tool = new SchemaTool($manager);
$tool->dropSchema($manager->getMetadataFactory()->getAllMetadata());
```
> Parameter #1 $classes of method Doctrine\ORM\Tools\SchemaTool::dropSchema() expects list<Doctrine\ORM\Mapping\ClassMetadata>,    
         array<Doctrine\ORM\Mapping\ClassMetadata> given.

Looking at the `getAllMetadata` implementation the return value is a list.
So I tried updated some phpdoc when the method is returning a list.