### PR TITLE
Add type to `ColocatedMappingDriver::isTransient()`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,36 +21,6 @@ parameters:
 			path: src/Persistence/Reflection/TypedNoDefaultRuntimePublicReflectionProperty.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\MappingDriver\\:\\:addExcludePaths\\(\\)\\.$#"
-			count: 1
-			path: tests/Persistence/Mapping/ColocatedMappingDriverTest.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\MappingDriver\\:\\:addPaths\\(\\)\\.$#"
-			count: 1
-			path: tests/Persistence/Mapping/ColocatedMappingDriverTest.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\MappingDriver\\:\\:getExcludePaths\\(\\)\\.$#"
-			count: 2
-			path: tests/Persistence/Mapping/ColocatedMappingDriverTest.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\MappingDriver\\:\\:getFileExtension\\(\\)\\.$#"
-			count: 2
-			path: tests/Persistence/Mapping/ColocatedMappingDriverTest.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\MappingDriver\\:\\:getPaths\\(\\)\\.$#"
-			count: 2
-			path: tests/Persistence/Mapping/ColocatedMappingDriverTest.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\MappingDriver\\:\\:setFileExtension\\(\\)\\.$#"
-			count: 1
-			path: tests/Persistence/Mapping/ColocatedMappingDriverTest.php
-
-		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with array\\{'Doctrine\\\\\\\\Tests…', 'Doctrine\\\\\\\\Tests\\\\\\\\ORM…', 'Doctrine\\\\\\\\Tests\\\\\\\\ORM…'\\} and array\\<int, class\\-string\\> will always evaluate to false\\.$#"
 			count: 1
 			path: tests/Persistence/Mapping/DriverChainTest.php

--- a/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
+++ b/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
@@ -128,12 +128,11 @@ trait ColocatedMappingDriver
      * Returns whether the class with the specified name is transient. Only non-transient
      * classes, that is entities and mapped superclasses, should have their metadata loaded.
      *
-     * @param string $className
      * @psalm-param class-string $className
      *
      * @return bool
      */
-    abstract public function isTransient($className);
+    abstract public function isTransient(string $className);
 
     /**
      * Gets the names of all mapped classes known to this driver.

--- a/tests/Persistence/Mapping/ColocatedMappingDriverTest.php
+++ b/tests/Persistence/Mapping/ColocatedMappingDriverTest.php
@@ -71,7 +71,7 @@ class ColocatedMappingDriverTest extends TestCase
         yield 'winding path' => [__DIR__ . '/../Mapping/_files/colocated'];
     }
 
-    protected function createDriver(string $path): MappingDriver
+    private function createDriver(string $path): MyDriver
     {
         return new MyDriver($path);
     }
@@ -94,10 +94,7 @@ final class MyDriver implements MappingDriver
     {
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function isTransient($className): bool
+    public function isTransient(string $className): bool
     {
         return $className !== TestClass::class;
     }


### PR DESCRIPTION
The `MappingDriver::isTransient()` was upgraded with a type for the `$className` parameter, but apparently we forgot to do the same on the `ColocatedMappingDriver` trait. This PR corrects this mistake. Adding the type to an abstract method should be safe in PHP 7.2 and up.