### PR TITLE
Remove doctrine/annotations dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "phpstan/phpstan": "1.9.4",
         "phpstan/phpstan-phpunit": "^1",
         "phpstan/phpstan-strict-rules": "^1.1",
-        "doctrine/annotations": "^1.7",
         "doctrine/coding-standard": "^11",
         "doctrine/common": "^3.0",
         "phpunit/phpunit": "^8.5 || ^9.5",
@@ -37,7 +36,6 @@
         "vimeo/psalm": "4.30.0 || 5.3.0"
     },
     "conflict": {
-        "doctrine/annotations": "<1.7 || >=2.0",
         "doctrine/common": "<2.10"
     },
     "autoload": {

--- a/tests/Persistence/Mapping/_files/colocated/TestClass.php
+++ b/tests/Persistence/Mapping/_files/colocated/TestClass.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine;
 
-/** @Doctrine\Entity */
 class TestClass
 {
 }
 
-/** @Annotation */
 class Entity
 {
 }


### PR DESCRIPTION
Since the removal of `AnnotationDriver`, the Persistence does not use the Annotations library anymore and therefore should not have an opinion on if and which version of the Annotations library is installed.