### PR TITLE
Allow Annotations 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "composer/package-versions-deprecated": "^1.11",
         "phpstan/phpstan": "~1.4.10 || 1.9.4",
-        "doctrine/annotations": "^1.0",
+        "doctrine/annotations": "^1 || ^2",
         "doctrine/coding-standard": "^9 || ^11",
         "doctrine/common": "^3.0",
         "phpunit/phpunit": "^7.5.20 || ^8.5 || ^9.5",
@@ -38,7 +38,7 @@
         "vimeo/psalm": "4.30.0 || 5.3.0"
     },
     "conflict": {
-        "doctrine/annotations": "<1.0 || >=2.0",
+        "doctrine/annotations": "<1.0 || >=3.0",
         "doctrine/common": "<2.10"
     },
     "autoload": {


### PR DESCRIPTION
We have unblocked Doctrine Annotations 2 on the 3.1.x branch already, but let's do so here as well. Persistence does not use any deprecated APIs and thus should not prevent the installation of Annotations 2.