### PR TITLE
Support array of enums

### DIFF
--- a/src/Persistence/Reflection/EnumReflectionProperty.php
+++ b/src/Persistence/Reflection/EnumReflectionProperty.php
@@ -8,6 +8,9 @@ use BackedEnum;
 use ReflectionProperty;
 use ReturnTypeWillChange;
 
+use function array_map;
+use function is_array;
+
 /**
  * PHP Enum Reflection Property - special override for backed enums.
  */
@@ -33,7 +36,7 @@ class EnumReflectionProperty extends ReflectionProperty
      *
      * @param object|null $object
      *
-     * @return int|string|null
+     * @return int|string|int[]|string[]|null
      */
     #[ReturnTypeWillChange]
     public function getValue($object = null)
@@ -48,7 +51,7 @@ class EnumReflectionProperty extends ReflectionProperty
             return null;
         }
 
-        return $enum->value;
+        return $this->fromEnum($enum);
     }
 
     /**
@@ -60,9 +63,39 @@ class EnumReflectionProperty extends ReflectionProperty
     public function setValue($object, $value = null): void
     {
         if ($value !== null) {
-            $value = $this->enumType::from($value);
+            $value = $this->toEnum($value);
         }
 
         $this->originalReflectionProperty->setValue($object, $value);
+    }
+
+    /**
+     * @param BackedEnum|BackedEnum[] $enum
+     *
+     * @return ($enum is BackedEnum ? (string|int) : (string[]|int[]))
+     */
+    private function fromEnum($enum)
+    {
+        if (is_array($enum)) {
+            return array_map(static function (BackedEnum $enum) {
+                return $enum->value;
+            }, $enum);
+        }
+
+        return $enum->value;
+    }
+
+    /**
+     * @param int|string|int[]|string[] $value
+     *
+     * @return ($value is int|string ? BackedEnum : BackedEnum[])
+     */
+    private function toEnum($value)
+    {
+        if (is_array($value)) {
+            return array_map([$this->enumType, 'from'], $value);
+        }
+
+        return $this->enumType::from($value);
     }
 }

--- a/tests_php81/Persistence/Reflection/EnumReflectionPropertyTest.php
+++ b/tests_php81/Persistence/Reflection/EnumReflectionPropertyTest.php
@@ -29,7 +29,6 @@ class EnumReflectionPropertyTest extends TestCase
 
         $reflProperty->setValue($object);
         self::assertNull($reflProperty->getValue($object));
-        /** @psalm-suppress TypeDoesNotContainNull */
         self::assertNull($object->suit);
 
         $reflProperty->setValue($object, 'D');
@@ -45,11 +44,33 @@ class EnumReflectionPropertyTest extends TestCase
         $this->expectException(ValueError::class);
         $reflProperty->setValue($object, 'A');
     }
+
+    public function testSetValidArrayValue(): void
+    {
+        $object        = new TypedEnumClass();
+        $object->suits = [Suit::Hearts, Suit::Clubs];
+
+        $reflProperty = new EnumReflectionProperty(new ReflectionProperty(TypedEnumClass::class, 'suits'), Suit::class);
+
+        $reflProperty->setValue($object);
+        self::assertNull($reflProperty->getValue($object));
+        self::assertNull($object->suits);
+
+        $reflProperty->setValue($object, []);
+        self::assertSame([], $reflProperty->getValue($object));
+        self::assertSame([], $object->suits);
+
+        $reflProperty->setValue($object, ['H', 'D']);
+        self::assertSame(['H', 'D'], $reflProperty->getValue($object));
+        self::assertSame([Suit::Hearts, Suit::Diamonds], $object->suits);
+    }
 }
 
 class TypedEnumClass
 {
     public ?Suit $suit = null;
+
+    public ?array $suits = null;
 }
 
 enum Suit: string


### PR DESCRIPTION
Support array of enums, so that e.g. with ODM you can do something like this

```php
#[Field(enumType: Variant::class]
private array $variants = [];
```