### PR TITLE
Add ObjectManager::isUninitializedObject()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,12 +6,14 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
-# Upgrade to 3.1
+# Upgrade to 3.3
 
-## Added method `Proxy::__setInitialized()`
+## Added method `ObjectManager::isUninitializedObject()`
 
-Classes implementing `Doctrine\Persistence\Proxy` should implement the new
+Classes implementing `Doctrine\Persistence\ObjectManager` should implement the new
 method. This method will be added to the interface in 4.0.
+
+# Upgrade to 3.1
 
 ## Deprecated `RuntimePublicReflectionProperty`
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: src/Persistence/Reflection/EnumReflectionProperty.php
 
 		-
-			message: "#^Call to function method_exists\\(\\) with Doctrine\\\\Persistence\\\\Proxy and '__setInitialized' will always evaluate to true\\.$#"
-			count: 1
-			path: src/Persistence/Reflection/RuntimeReflectionProperty.php
-
-		-
 			message: "#^Variable property access on \\$this\\(Doctrine\\\\Persistence\\\\Reflection\\\\TypedNoDefaultRuntimePublicReflectionProperty\\)\\.$#"
 			count: 1
 			path: src/Persistence/Reflection/TypedNoDefaultRuntimePublicReflectionProperty.php

--- a/src/Persistence/ObjectManager.php
+++ b/src/Persistence/ObjectManager.php
@@ -9,6 +9,8 @@ use Doctrine\Persistence\Mapping\ClassMetadataFactory;
 
 /**
  * Contract for a Doctrine persistence layer ObjectManager class to implement.
+ *
+ * @method bool isUninitializedObject(mixed $value) Implementing this method will be mandatory in version 4.
  */
 interface ObjectManager
 {

--- a/src/Persistence/Proxy.php
+++ b/src/Persistence/Proxy.php
@@ -8,7 +8,6 @@ namespace Doctrine\Persistence;
  * Interface for proxy classes.
  *
  * @template T of object
- * @method void __setInitialized(bool $initialized) Implementing this method will be mandatory in version 4.
  */
 interface Proxy
 {


### PR DESCRIPTION
For 3.3

Adding `ObjectManager::isUninitializedObject()` will allow userland to decouple from the `Proxy` interface:

before:
```php
if ($entity instanceof Proxy && !$entity->__isInitialized()) {
    $entity->__load();
}
```

after:
```php
if ($em->isUninitializedObject($entity)) {
    $em->initializeObject($entity);
}
```

Also, I removed `Proxy::__setInitialized()` as I figured out it shouldn't be exposed as public API and it should remain an internal concern.