### PR TITLE
Fix bug in namespace check in MappingDriverChain

### DIFF
--- a/src/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/src/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -8,8 +8,9 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\MappingException;
 
 use function array_keys;
+use function dirname;
 use function spl_object_hash;
-use function strpos;
+use function trim;
 
 /**
  * The DriverChain allows you to add multiple other mapping drivers for
@@ -73,7 +74,7 @@ class MappingDriverChain implements MappingDriver
     public function loadMetadataForClass(string $className, ClassMetadata $metadata)
     {
         foreach ($this->drivers as $namespace => $driver) {
-            if (strpos($className, $namespace . '\\') === 0) {
+            if (self::isMatchingNamespace($className, $namespace)) {
                 $driver->loadMetadataForClass($className, $metadata);
 
                 return;
@@ -105,7 +106,7 @@ class MappingDriverChain implements MappingDriver
             }
 
             foreach ($driverClasses[$oid] as $className) {
-                if (strpos($className, $namespace . '\\') !== 0) {
+                if (! self::isMatchingNamespace($className, $namespace)) {
                     continue;
                 }
 
@@ -128,7 +129,7 @@ class MappingDriverChain implements MappingDriver
     public function isTransient(string $className)
     {
         foreach ($this->drivers as $namespace => $driver) {
-            if (strpos($className, $namespace . '\\') === 0) {
+            if (self::isMatchingNamespace($className, $namespace)) {
                 return $driver->isTransient($className);
             }
         }
@@ -138,5 +139,13 @@ class MappingDriverChain implements MappingDriver
         }
 
         return true;
+    }
+
+    /**
+     * Checks if the given class name matches the namespace.
+     */
+    protected static function isMatchingNamespace(string $className, string $namespace): bool
+    {
+        return dirname($className) === trim($namespace, '\\');
     }
 }

--- a/src/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/src/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -73,7 +73,7 @@ class MappingDriverChain implements MappingDriver
     public function loadMetadataForClass(string $className, ClassMetadata $metadata)
     {
         foreach ($this->drivers as $namespace => $driver) {
-            if (strpos($className, $namespace) === 0) {
+            if (strpos($className, $namespace . '\\') === 0) {
                 $driver->loadMetadataForClass($className, $metadata);
 
                 return;
@@ -105,7 +105,7 @@ class MappingDriverChain implements MappingDriver
             }
 
             foreach ($driverClasses[$oid] as $className) {
-                if (strpos($className, $namespace) !== 0) {
+                if (strpos($className, $namespace . '\\') !== 0) {
                     continue;
                 }
 
@@ -128,7 +128,7 @@ class MappingDriverChain implements MappingDriver
     public function isTransient(string $className)
     {
         foreach ($this->drivers as $namespace => $driver) {
-            if (strpos($className, $namespace) === 0) {
+            if (strpos($className, $namespace . '\\') === 0) {
                 return $driver->isTransient($className);
             }
         }

--- a/tests/Persistence/Mapping/DriverChainTest.php
+++ b/tests/Persistence/Mapping/DriverChainTest.php
@@ -147,6 +147,24 @@ class DriverChainTest extends DoctrineTestCase
 
         self::assertSame(['Doctrine\Tests\Models\Company\Foo', 'Other\Class'], $classNames);
     }
+
+    public function testMatchingNamespace(): void
+    {
+        // Expose the protected method as public
+        $mdc = new class extends MappingDriverChain {
+            public static function isMatchingNamespace(string $className, string $namespace): bool
+            {
+                return parent::isMatchingNamespace($className, $namespace);
+            }
+        };
+
+        $className = DriverChainEntity::class;
+
+        self::assertTrue($mdc::isMatchingNamespace($className, 'Doctrine\Tests\Persistence\Mapping\\'));
+        self::assertTrue($mdc::isMatchingNamespace($className, 'Doctrine\Tests\Persistence\Mapping'));
+        self::assertFalse($mdc::isMatchingNamespace($className, 'Doctrine\Tests\Persistence\Map'));
+        self::assertFalse($mdc::isMatchingNamespace($className, 'Doctrine\Tests\Persistence'));
+    }
 }
 
 class DriverChainEntity

--- a/tests/Persistence/Mapping/DriverChainTest.php
+++ b/tests/Persistence/Mapping/DriverChainTest.php
@@ -63,7 +63,7 @@ class DriverChainTest extends DoctrineTestCase
         $driver1 = $this->createMock(MappingDriver::class);
         $driver1->expects(self::once())
                 ->method('getAllClassNames')
-                ->will(self::returnValue(['Doctrine\Tests\Models\Company\Foo','Doctrine\Tests\Models\Company2\Foo']));
+                ->will(self::returnValue(['Doctrine\Tests\Models\Company\Foo', 'Doctrine\Tests\Models\Company2\Foo']));
 
         $driver2 = $this->createMock(MappingDriver::class);
         $driver2->expects(self::once())

--- a/tests/Persistence/Mapping/DriverChainTest.php
+++ b/tests/Persistence/Mapping/DriverChainTest.php
@@ -37,7 +37,7 @@ class DriverChainTest extends DoctrineTestCase
                 ->with(self::equalTo($className))
                 ->willReturn(true);
 
-        $chain->addDriver($driver1, 'Doctrine\Tests\Models\Company');
+        $chain->addDriver($driver1, 'Doctrine\Tests\Persistence\Map');
         $chain->addDriver($driver2, 'Doctrine\Tests\Persistence\Mapping');
 
         $chain->loadMetadataForClass($className, $classMetadata);
@@ -63,7 +63,7 @@ class DriverChainTest extends DoctrineTestCase
         $driver1 = $this->createMock(MappingDriver::class);
         $driver1->expects(self::once())
                 ->method('getAllClassNames')
-                ->will(self::returnValue(['Doctrine\Tests\Models\Company\Foo']));
+                ->will(self::returnValue(['Doctrine\Tests\Models\Company\Foo','Doctrine\Tests\Models\Company2\Foo']));
 
         $driver2 = $this->createMock(MappingDriver::class);
         $driver2->expects(self::once())


### PR DESCRIPTION
This fix improves the checking if a namespace appears in a className by ensuring that the namespace ends in a `\`.  Prior to this fix, the following would occur:

A className such as `Doctrine\Tests\Persistence\Mapping\DriverChainEntity` would match the namespace: `Doctrine\Tests\Persistence\Map`, which isn't correct.

Other considerations:  
- what if the namespace already ends in a `\`?  is this a valid case? Probably not.
- what if it's a parent namespace.  In the above example, this would be `Doctrine\Tests\Persistence`.  Should this match against the className `Doctrine\Tests\Persistence\Mapping\DriverChainEntity` or not?  The current logic would match, but I'm not sure if it should....