### PR TITLE
Bugfix: Parent methods in extended EnumReflectionProperty didn't work.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: src/Persistence/Mapping/Driver/StaticPHPDriver.php
 
 		-
-			message: "#^Doctrine\\\\Persistence\\\\Reflection\\\\EnumReflectionProperty\\:\\:__construct\\(\\) does not call parent constructor from ReflectionProperty\\.$#"
-			count: 1
-			path: src/Persistence/Reflection/EnumReflectionProperty.php
-
-		-
 			message: "#^Call to function method_exists\\(\\) with Doctrine\\\\Persistence\\\\Proxy and '__setInitialized' will always evaluate to true\\.$#"
 			count: 1
 			path: src/Persistence/Reflection/RuntimeReflectionProperty.php

--- a/src/Persistence/Reflection/EnumReflectionProperty.php
+++ b/src/Persistence/Reflection/EnumReflectionProperty.php
@@ -27,6 +27,7 @@ class EnumReflectionProperty extends ReflectionProperty
     {
         $this->originalReflectionProperty = $originalReflectionProperty;
         $this->enumType                   = $enumType;
+
         parent::__construct($originalReflectionProperty->class, $originalReflectionProperty->name);
     }
 

--- a/src/Persistence/Reflection/EnumReflectionProperty.php
+++ b/src/Persistence/Reflection/EnumReflectionProperty.php
@@ -27,6 +27,7 @@ class EnumReflectionProperty extends ReflectionProperty
     {
         $this->originalReflectionProperty = $originalReflectionProperty;
         $this->enumType                   = $enumType;
+        parent::__construct($originalReflectionProperty->class, $originalReflectionProperty->name);
     }
 
     /**

--- a/tests_php81/Persistence/Reflection/EnumReflectionPropertyTest.php
+++ b/tests_php81/Persistence/Reflection/EnumReflectionPropertyTest.php
@@ -64,6 +64,14 @@ class EnumReflectionPropertyTest extends TestCase
         self::assertSame(['H', 'D'], $reflProperty->getValue($object));
         self::assertSame([Suit::Hearts, Suit::Diamonds], $object->suits);
     }
+
+    public function testParentReflectionPropertyMethods(): void
+    {
+        $reflProperty = new EnumReflectionProperty(new ReflectionProperty(TypedEnumClass::class, 'suit'), Suit::class);
+
+        self::assertIsArray($reflProperty->getAttributes());
+        self::assertIsInt($reflProperty->getModifiers());
+    }
 }
 
 class TypedEnumClass


### PR DESCRIPTION
EnumReflectionProperty extends ReflectionProperty without ReflectionProperty::__constructor() call making it impossible to use parent methods such as ReflectionProperty::getAttributes() and others.