### PR TITLE
Add support for enum arguments to setValue()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,16 @@ parameters:
 			path: src/Persistence/Reflection/EnumReflectionProperty.php
 
 		-
+			message: "#^Method Doctrine\\\\Persistence\\\\Reflection\\\\EnumReflectionProperty\\:\\:toEnum\\(\\) should return array\\<BackedEnum\\>\\|BackedEnum but returns array\\<BackedEnum\\|int\\|string\\>\\.$#"
+			count: 1
+			path: src/Persistence/Reflection/EnumReflectionProperty.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(BackedEnum\\|int\\|string\\)\\: mixed\\)\\|null, array\\{class\\-string\\<BackedEnum\\>, 'from'\\} given\\.$#"
+			count: 1
+			path: src/Persistence/Reflection/EnumReflectionProperty.php
+
+		-
 			message: "#^Variable property access on \\$this\\(Doctrine\\\\Persistence\\\\Reflection\\\\TypedNoDefaultRuntimePublicReflectionProperty\\)\\.$#"
 			count: 1
 			path: src/Persistence/Reflection/TypedNoDefaultRuntimePublicReflectionProperty.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8,4 +8,12 @@
       <code>$parentClass === false</code>
     </TypeDoesNotContainType>
   </file>
+  <file src="src/Persistence/Reflection/EnumReflectionProperty.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>$value</code>
+    </InvalidReturnStatement>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$value</code>
+    </PossiblyInvalidArgument>
+  </file>
 </files>

--- a/src/Persistence/Reflection/EnumReflectionProperty.php
+++ b/src/Persistence/Reflection/EnumReflectionProperty.php
@@ -10,6 +10,7 @@ use ReturnTypeWillChange;
 
 use function array_map;
 use function is_array;
+use function reset;
 
 /**
  * PHP Enum Reflection Property - special override for backed enums.
@@ -86,13 +87,22 @@ class EnumReflectionProperty extends ReflectionProperty
     }
 
     /**
-     * @param int|string|int[]|string[] $value
+     * @param int|string|int[]|string[]|BackedEnum|BackedEnum[] $value
      *
-     * @return ($value is int|string ? BackedEnum : BackedEnum[])
+     * @return ($value is int|string|BackedEnum ? BackedEnum : BackedEnum[])
      */
     private function toEnum($value)
     {
+        if ($value instanceof BackedEnum) {
+            return $value;
+        }
+
         if (is_array($value)) {
+            $v = reset($value);
+            if ($v instanceof BackedEnum) {
+                return $value;
+            }
+
             return array_map([$this->enumType, 'from'], $value);
         }
 

--- a/tests_php81/Persistence/Reflection/EnumReflectionPropertyTest.php
+++ b/tests_php81/Persistence/Reflection/EnumReflectionPropertyTest.php
@@ -64,6 +64,24 @@ class EnumReflectionPropertyTest extends TestCase
         self::assertSame(['H', 'D'], $reflProperty->getValue($object));
         self::assertSame([Suit::Hearts, Suit::Diamonds], $object->suits);
     }
+
+    public function testSetEnum(): void
+    {
+        $object       = new TypedEnumClass();
+        $reflProperty = new EnumReflectionProperty(new ReflectionProperty(TypedEnumClass::class, 'suit'), Suit::class);
+        $reflProperty->setValue($object, Suit::Hearts);
+
+        self::assertSame(Suit::Hearts, $object->suit);
+    }
+
+    public function testSetEnumArray(): void
+    {
+        $object       = new TypedEnumClass();
+        $reflProperty = new EnumReflectionProperty(new ReflectionProperty(TypedEnumClass::class, 'suits'), Suit::class);
+        $reflProperty->setValue($object, [Suit::Hearts, Suit::Diamonds]);
+
+        self::assertSame([Suit::Hearts, Suit::Diamonds], $object->suits);
+    }
 }
 
 class TypedEnumClass


### PR DESCRIPTION

The ORM is relying on that feature.
When trying to use `EnumReflectionProperty` instead of the corresponding class, the test suite breaks on this line: https://github.com/doctrine/orm/blob/b187bc85881cc85d36b28e7ed9dbe2071d472e30/src/UnitOfWork.php#L2406



`EnumReflectionProperty` was added https://github.com/doctrine/persistence/pull/248 so that it could reduce duplication with the ORM, but is not used yet.
