### PR TITLE
Stop maintaining 2.x

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -36,7 +36,7 @@
             "name": "2.5",
             "branchName": "2.5.x",
             "slug": "2.5",
-            "maintained": true
+            "maintained": false
         },
         {
             "name": "2.4",


### PR DESCRIPTION
The number of daily installs is comparable with 1.x, which we are no longer maintaining, and the last release is more than 1 year old, meaning we haven't felt the need to patch anything in more than 1 year.