### PR TITLE
fix: Failing to retrieve reflection property on enum

### DIFF
--- a/src/Persistence/Reflection/EnumReflectionProperty.php
+++ b/src/Persistence/Reflection/EnumReflectionProperty.php
@@ -168,4 +168,14 @@ class EnumReflectionProperty extends ReflectionProperty
     {
         return $this->originalReflectionProperty->getDocComment();
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @psalm-external-mutation-free
+     */
+    public function isPrivate(): bool
+    {
+        return $this->originalReflectionProperty->isPrivate();
+    }
 }

--- a/tests_php81/Persistence/Reflection/EnumReflectionPropertyTest.php
+++ b/tests_php81/Persistence/Reflection/EnumReflectionPropertyTest.php
@@ -125,6 +125,12 @@ class EnumReflectionPropertyTest extends TestCase
         $reflProperty = new EnumReflectionProperty(new ReflectionProperty(TypedEnumClass::class, 'suit'), Suit::class);
         self::assertStringContainsString('@MyDoc', $reflProperty->getDocComment());
     }
+
+    public function testIsPrivate(): void
+    {
+        $reflProperty = new EnumReflectionProperty(new ReflectionProperty(TypedEnumClass::class, 'suit'), Suit::class);
+        self::assertFalse($reflProperty->isPrivate());
+    }
 }
 
 #[Attribute(Attribute::TARGET_PROPERTY)]


### PR DESCRIPTION
This PR should fix an issue with the property isPrivate from inheritance on `ReflectionProperty`.


 In `EnumReflectionProperty` the method `isPrivate` should be executed on the `originalReflectionProperty` to prevent fatal error : 

```
Internal error: Failed to retrieve the reflection object
```

This commit just override the method and check the privacy on the originalReflectionProperty.