### PR TITLE
Handle the correct zero-value

### DIFF
--- a/src/Persistence/Mapping/Driver/FileDriver.php
+++ b/src/Persistence/Mapping/Driver/FileDriver.php
@@ -173,7 +173,7 @@ abstract class FileDriver implements MappingDriver
     protected function initialize()
     {
         $this->classCache = [];
-        if ($this->globalBasename === null) {
+        if ($this->globalBasename === '') {
             return;
         }
 


### PR DESCRIPTION
It was changed in 3e2fad57e1f180e9d6f827c17548171959c1a9a7, I am not sure why, ~I think it might be to avoid the extra conditions / complexity I'm adding here.~ What I know is that it makes a guard condition in `FileDriver::initialize()` useless, most likely resulting in persistence looking for a file with a name consisting only in an extension (`.php`, `.yml`…).

https://github.com/doctrine/persistence/blob/267cd9f317ae4fa9d3b2b02726bbf9cb060da3e6/src/Persistence/Mapping/Driver/FileDriver.php#L173-L191