### PR TITLE
Implement isUninitializedObject() in ObjectManagerDecorator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpstan/phpstan-strict-rules": "^1.1",
         "doctrine/coding-standard": "^12",
         "doctrine/common": "^3.0",
-        "phpunit/phpunit": "^8.5 || ^9.5",
+        "phpunit/phpunit": "^8.5.38 || ^9.5",
         "symfony/cache": "^4.4 || ^5.4 || ^6.0",
         "vimeo/psalm": "4.30.0 || 5.24.0"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,6 +6,11 @@ parameters:
 			path: src/Persistence/Mapping/Driver/StaticPHPDriver.php
 
 		-
+			message: "#^Call to function method_exists\\(\\) with TObjectManager of Doctrine\\\\Persistence\\\\ObjectManager and 'isUninitializedObje…' will always evaluate to true\\.$#"
+			count: 1
+			path: src/Persistence/ObjectManagerDecorator.php
+
+		-
 			message: "#^Doctrine\\\\Persistence\\\\Reflection\\\\EnumReflectionProperty\\:\\:__construct\\(\\) does not call parent constructor from ReflectionProperty\\.$#"
 			count: 1
 			path: src/Persistence/Reflection/EnumReflectionProperty.php

--- a/src/Persistence/ObjectManagerDecorator.php
+++ b/src/Persistence/ObjectManagerDecorator.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\Persistence;
 
+use BadMethodCallException;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\ClassMetadataFactory;
+
+use function get_class;
+use function method_exists;
+use function sprintf;
 
 /**
  * Base class to simplify ObjectManager decorators
@@ -80,6 +85,29 @@ abstract class ObjectManagerDecorator implements ObjectManager
     public function initializeObject(object $obj)
     {
         $this->wrapped->initializeObject($obj);
+    }
+
+    /** @param mixed $value */
+    public function isUninitializedObject($value): bool
+    {
+        if (! method_exists($this->wrapped, 'isUninitializedObject')) {
+            $wrappedClass = get_class($this->wrapped);
+
+            throw new BadMethodCallException(sprintf(
+                <<<'EXCEPTION'
+Context: Trying to call %s
+Problem: The wrapped ObjectManager, an instance of %s does not implement this method.
+Solution: Implement %s::isUninitializedObject() with a signature compatible with this one:
+    public function isUninitializedObject(mixed $value): bool
+EXCEPTION
+                ,
+                __METHOD__,
+                $wrappedClass,
+                $wrappedClass
+            ));
+        }
+
+        return $this->wrapped->isUninitializedObject($value);
     }
 
     /**


### PR DESCRIPTION
That method will be part of the ObjectManager interface in 4.0.x.

It was introduced in https://github.com/doctrine/persistence/pull/334