### PR TITLE
Make types compatible with ORM/ODM drivers

### DIFF
--- a/src/Persistence/Mapping/Driver/FileDriver.php
+++ b/src/Persistence/Mapping/Driver/FileDriver.php
@@ -21,6 +21,8 @@ use function str_replace;
  * classes on demand. This requires the user to adhere to the convention of 1 mapping
  * file per class and the file names of the mapping files must correspond to the full
  * class name, including namespace, with the namespace delimiters '\', replaced by dots '.'.
+ *
+ * @template T
  */
 abstract class FileDriver implements MappingDriver
 {
@@ -28,8 +30,8 @@ abstract class FileDriver implements MappingDriver
     protected $locator;
 
     /**
-     * @var ClassMetadata[]|null
-     * @psalm-var array<class-string, ClassMetadata<object>>|null
+     * @var mixed[]|null
+     * @psalm-var array<class-string, T>|null
      */
     protected $classCache;
 
@@ -78,8 +80,7 @@ abstract class FileDriver implements MappingDriver
      *
      * @psalm-param class-string $className
      *
-     * @return ClassMetadata The element of schema meta data.
-     * @psalm-return ClassMetadata<object>
+     * @return T The element of schema meta data.
      *
      * @throws MappingException
      */
@@ -154,8 +155,8 @@ abstract class FileDriver implements MappingDriver
      *
      * @param string $file The mapping file to load.
      *
-     * @return ClassMetadata[]
-     * @psalm-return array<class-string, ClassMetadata<object>>
+     * @return mixed[]
+     * @psalm-return array<class-string, T>
      */
     abstract protected function loadMappingFile(string $file);
 

--- a/src/Persistence/Mapping/Driver/PHPDriver.php
+++ b/src/Persistence/Mapping/Driver/PHPDriver.php
@@ -9,6 +9,8 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 /**
  * The PHPDriver includes php files which just populate ClassMetadataInfo
  * instances with plain PHP code.
+ *
+ * @template-extends FileDriver<ClassMetadata<object>>
  */
 class PHPDriver extends FileDriver
 {

--- a/tests/Persistence/Mapping/FileDriverTest.php
+++ b/tests/Persistence/Mapping/FileDriverTest.php
@@ -197,6 +197,7 @@ class FileDriverTest extends DoctrineTestCase
     }
 }
 
+/** @template-extends FileDriver<TestClassMetadata<object>> */
 class TestFileDriver extends FileDriver
 {
     /** @var ClassMetadata<object> */

--- a/tests/Persistence/Mapping/Fixtures/TestClassMetadata.php
+++ b/tests/Persistence/Mapping/Fixtures/TestClassMetadata.php
@@ -9,7 +9,7 @@ use LogicException;
 use ReflectionClass;
 
 /**
- * @template T of object
+ * @template-covariant T of object
  * @template-implements ClassMetadata<T>
  */
 final class TestClassMetadata implements ClassMetadata


### PR DESCRIPTION
It does not look like the implementations for these methods every return ClassMetadata objects.