### PR TITLE
Deprecate static reflection service

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,13 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
+# Upgrade to 3.4
+
+## Deprecated `StaticReflectionService`
+
+The class `Doctrine\Persistence\Mapping\StaticReflectionService` is deprecated
+without replacement.
+
 # Upgrade to 3.3
 
 ## Added method `ObjectManager::isUninitializedObject()`

--- a/src/Persistence/Mapping/StaticReflectionService.php
+++ b/src/Persistence/Mapping/StaticReflectionService.php
@@ -11,6 +11,8 @@ use function substr;
 
 /**
  * PHP Runtime Reflection Service.
+ *
+ * @deprecated No replacement planned
  */
 class StaticReflectionService implements ReflectionService
 {


### PR DESCRIPTION
It is unused, and forces `ReflectionService::getClass()` to have a nullable return type.