### PR TITLE
Restore annotation

### DIFF
--- a/src/Persistence/Event/LoadClassMetadataEventArgs.php
+++ b/src/Persistence/Event/LoadClassMetadataEventArgs.php
@@ -36,7 +36,11 @@ class LoadClassMetadataEventArgs extends EventArgs
         return $this->classMetadata;
     }
 
-    /** Retrieves the associated ObjectManager. */
+    /**
+     * Retrieves the associated ObjectManager.
+     *
+     * @psalm-return TObjectManager
+     */
     public function getObjectManager(): ObjectManager
     {
         return $this->objectManager;


### PR DESCRIPTION
I wrongly dropped it while dropping PHP 8.1 support in #361 (probably didn't notice the T in TObjectManager).