### PR TITLE
Merge commit right before dropping Psalm into 4.0.x

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -12,6 +12,6 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@5.1.0"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@5.2.0"
     with:
       composer-root-version: "3.0"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   phpunit:
     name: "PHPUnit"
-    uses: "doctrine/.github/.github/workflows/continuous-integration.yml@5.1.0"
+    uses: "doctrine/.github/.github/workflows/continuous-integration.yml@5.2.0"
     with:
       composer-root-version: "3.0"
       php-versions: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: "Git tag, release & create merge-up PR"
-    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@5.1.0"
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@5.2.0"
     secrets:
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
       GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,6 +12,6 @@ on:
 jobs:
   static-analysis:
     name: "Static Analysis"
-    uses: "doctrine/.github/.github/workflows/static-analysis.yml@5.1.0"
+    uses: "doctrine/.github/.github/workflows/static-analysis.yml@5.2.0"
     with:
       composer-root-version: "3.0"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "psr/cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "1.11.1",
+        "phpstan/phpstan": "1.12.7",
         "phpstan/phpstan-phpunit": "^1",
         "phpstan/phpstan-strict-rules": "^1.1",
         "doctrine/coding-standard": "^12",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "doctrine/common": "^3.0",
         "phpunit/phpunit": "^8.5 || ^9.5",
         "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0",
-        "vimeo/psalm": "4.30.0 || 5.24.0"
+        "vimeo/psalm": "4.30.0 || 5.26.1"
     },
     "conflict": {
         "doctrine/common": "<2.10"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/coding-standard": "^12",
         "doctrine/common": "^3.0",
         "phpunit/phpunit": "^8.5 || ^9.5",
-        "symfony/cache": "^4.4 || ^5.4 || ^6.0",
+        "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0",
         "vimeo/psalm": "4.30.0 || 5.24.0"
     },
     "conflict": {

--- a/tests/Persistence/Mapping/AbstractClassMetadataFactoryTest.php
+++ b/tests/Persistence/Mapping/AbstractClassMetadataFactoryTest.php
@@ -86,7 +86,7 @@ final class AbstractClassMetadataFactoryTest extends DoctrineTestCase
             ->method('newClassMetadataInstance')
             ->with(SomeOtherEntity::class)
             ->willReturn(
-                $this->createStub(ClassMetadata::class)
+                self::createStub(ClassMetadata::class)
             );
 
         /** @psalm-suppress ArgumentTypeCoercion */


### PR DESCRIPTION
The commit that drops Psalm causes too many conflicts. It will be easier to just do another MR targeting 4.0.x