### PR TITLE
Migrate to robust urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ The Doctrine Persistence project is a library that provides common abstractions 
 
   [Coverage 3.3 image]: https://codecov.io/gh/doctrine/persistence/branch/3.3.x/graph/badge.svg
   [CodeCov 3.3]: https://codecov.io/gh/doctrine/persistence/branch/3.3.x
-  [GA 3.3 image]: https://github.com/doctrine/persistence/workflows/Continuous%20Integration/badge.svg?branch=3.3.x
-  [GA 3.3]: https://github.com/doctrine/persistence/actions?query=workflow%3A%22Continuous+Integration%22+branch%3A3.3.x
+  [GA 3.3 image]: https://github.com/doctrine/persistence/actions/workflows/continuous-integration.yml/badge.svg?branch=3.3.x
+  [GA 3.3]: https://github.com/doctrine/persistence/actions/workflows/continuous-integration.yml?branch=3.3.x


### PR DESCRIPTION
Looks like using the urls with url-encoded workflow names no longer works. Using the "create status badge" UI provides the url I'm using here.