### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -5,16 +5,28 @@
     "docsSlug": "doctrine-persistence",
     "versions": [
         {
-            "name": "4.0",
-            "branchName": "4.0.x",
+            "name": "5.0",
+            "branchName": "5.0.x",
             "slug": "latest",
             "upcoming": true
+        },
+        {
+            "name": "4.1",
+            "branchName": "4.1.x",
+            "slug": "4.1",
+            "upcoming": true
+        },
+        {
+            "name": "4.0",
+            "branchName": "4.0.x",
+            "slug": "4.0",
+            "current": true
         },
         {
             "name": "3.4",
             "branchName": "3.4.x",
             "slug": "3.4",
-            "current": true
+            "maintained": true
         },
         {
             "name": "3.3",


### PR DESCRIPTION
New branches:

- 5.0.x
- 4.1.x

3.4.x is still maintained, but is no longer the default branch (it is a legacy patch branch).

4.0.x is the new default branch.