### PR TITLE
Fix RuntimeReflectionProperty not working with static properties

### DIFF
--- a/src/Persistence/Reflection/RuntimeReflectionProperty.php
+++ b/src/Persistence/Reflection/RuntimeReflectionProperty.php
@@ -38,7 +38,7 @@ class RuntimeReflectionProperty extends ReflectionProperty
     #[ReturnTypeWillChange]
     public function getValue($object = null)
     {
-        if ($object === null) {
+        if ($object === null || $this->isStatic()) {
             return parent::getValue($object);
         }
 
@@ -56,7 +56,7 @@ class RuntimeReflectionProperty extends ReflectionProperty
     #[ReturnTypeWillChange]
     public function setValue($object, $value = null)
     {
-        if (! ($object instanceof Proxy && ! $object->__isInitialized())) {
+        if ((! ($object instanceof Proxy && ! $object->__isInitialized())) || $this->isStatic()) {
             parent::setValue($object, $value);
 
             return;

--- a/tests/Persistence/RuntimeReflectionPropertyTest.php
+++ b/tests/Persistence/RuntimeReflectionPropertyTest.php
@@ -27,6 +27,7 @@ class RuntimeReflectionPropertyTest extends TestCase
     /**
      * @testWith ["test", "testValue"]
      *           ["privateTest", "privateTestValue"]
+     *           ["staticTest", "staticTestValue"]
      */
     public function testGetSetValue(string $name, string $value): void
     {
@@ -64,6 +65,9 @@ class RuntimeReflectionPropertyTest extends TestCase
         self::assertSame('testValue', $reflProperty->getValue($mockProxy));
         unset($mockProxy->checkedProperty);
         self::assertNull($reflProperty->getValue($mockProxy));
+
+        $reflStaticProperty = new RuntimeReflectionProperty($proxyClass, 'staticCheckedProperty');
+        self::assertSame('testValue', $reflStaticProperty->getValue($mockProxy));
     }
 
     /**
@@ -90,6 +94,12 @@ class RuntimeReflectionPropertyTest extends TestCase
         unset($mockProxy->checkedProperty);
         $reflProperty->setValue($mockProxy, 'otherNewValue');
         self::assertSame('otherNewValue', $mockProxy->checkedProperty);
+
+        $reflStaticProperty = new RuntimeReflectionProperty($proxyClass, 'staticCheckedProperty');
+        $reflStaticProperty->setValue($mockProxy, 'staticNewValue');
+        self::assertSame('staticNewValue', $mockProxy::$staticCheckedProperty);
+        $reflStaticProperty->setValue($mockProxy, 'staticOtherNewValue');
+        self::assertSame('staticOtherNewValue', $mockProxy::$staticCheckedProperty);
 
         if (! $mockProxy instanceof CommonProxy) {
             return;
@@ -125,6 +135,9 @@ class RuntimeReflectionPropertyTestProxyMock implements Proxy
 
     /** @var string */
     public $checkedProperty = 'testValue';
+
+    /** @var string */
+    public static $staticCheckedProperty = 'testValue';
 
     /**
      * {@inheritDoc}
@@ -248,6 +261,9 @@ class RuntimeReflectionPropertyTestClass
 
     /** @var string|null */
     private $privateTest = 'privateTestValue';
+
+    /** @var string|null */
+    public static $staticTest = 'staticTestValue';
 
     public function getPrivateTest(): ?string
     {


### PR DESCRIPTION
Fixes #420.

My assumption here is that using the native `ReflectionProperty` for static properties won't cause the lazy proxy classes to get instantiated. The tests seem to confirm that.

