### PR TITLE
Remove Reflection*::setAccessible() calls

### DIFF
--- a/src/Persistence/Mapping/ReflectionService.php
+++ b/src/Persistence/Mapping/ReflectionService.php
@@ -49,7 +49,7 @@ interface ReflectionService
     public function getClass(string $class): ReflectionClass;
 
     /**
-     * Returns an accessible property (setAccessible(true)) or null.
+     * Returns an accessible property or null.
      *
      * @phpstan-param class-string $class
      */

--- a/src/Persistence/Mapping/RuntimeReflectionService.php
+++ b/src/Persistence/Mapping/RuntimeReflectionService.php
@@ -79,8 +79,6 @@ class RuntimeReflectionService implements ReflectionService
             $reflectionProperty = new TypedNoDefaultReflectionProperty($class, $property);
         }
 
-        $reflectionProperty->setAccessible(true);
-
         return $reflectionProperty;
     }
 

--- a/tests/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -187,7 +187,6 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
     private static function getCache(AbstractClassMetadataFactory $classMetadataFactory): CacheItemPoolInterface|null
     {
         $method = new ReflectionMethod($classMetadataFactory, 'getCache');
-        $method->setAccessible(true);
 
         return $method->invoke($classMetadataFactory);
     }

--- a/tests/Persistence/Reflection/TypedNoDefaultReflectionPropertyTest.php
+++ b/tests/Persistence/Reflection/TypedNoDefaultReflectionPropertyTest.php
@@ -29,7 +29,6 @@ class TypedNoDefaultReflectionPropertyTest extends TestCase
     public function testSetValueNull(): void
     {
         $reflection = new TypedNoDefaultReflectionProperty(TypedFoo::class, 'id');
-        $reflection->setAccessible(true);
 
         $object = new TypedFoo();
         $object->setId(1);
@@ -45,7 +44,6 @@ class TypedNoDefaultReflectionPropertyTest extends TestCase
     public function testSetValueNullOnNullableProperty(): void
     {
         $reflection = new TypedNoDefaultReflectionProperty(TypedNullableFoo::class, 'value');
-        $reflection->setAccessible(true);
 
         $object = new TypedNullableFoo();
 

--- a/tests/Persistence/RuntimeReflectionPropertyTest.php
+++ b/tests/Persistence/RuntimeReflectionPropertyTest.php
@@ -34,7 +34,6 @@ class RuntimeReflectionPropertyTest extends TestCase
 
         self::assertSame($value, $reflProperty->getValue($object));
 
-        $reflProperty->setAccessible(true);
         $reflProperty->setValue($object, 'changedValue');
 
         self::assertSame('changedValue', $reflProperty->getValue($object));


### PR DESCRIPTION
> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

(https://www.php.net/manual/en/reflectionmethod.setaccessible.php and https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

This package requires at least PHP 8.1.
Thus, the calls can be safely removed.

There're even plans to deprecate the method in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations