### PR TITLE
Feature: iterable source file path names for `ColocatedMappingDriver`

### DIFF
--- a/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
+++ b/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
@@ -33,6 +33,9 @@ use function str_replace;
  */
 trait ColocatedMappingDriver
 {
+    /** @var iterable<string> */
+    private iterable $sourceFilePathNames;
+
     /**
      * The paths where to look for mapping files.
      *
@@ -51,7 +54,7 @@ trait ColocatedMappingDriver
     protected string $fileExtension = '.php';
 
     /**
-     * Cache for getAllClassNames().
+     * Cache for {@see getAllClassNames()}.
      *
      * @var array<int, string>|null
      * @phpstan-var list<class-string>|null
@@ -79,7 +82,7 @@ trait ColocatedMappingDriver
     }
 
     /**
-     * Append exclude lookup paths to metadata driver.
+     * Append exclude lookup paths to a metadata driver.
      *
      * @param string[] $paths
      */
@@ -132,7 +135,7 @@ trait ColocatedMappingDriver
             return $this->classNames;
         }
 
-        if ($this->paths === []) {
+        if ($this->paths === [] && ! isset($this->sourceFilePathNames)) {
             throw MappingException::pathRequiredForDriver(static::class);
         }
 
@@ -157,7 +160,8 @@ trait ColocatedMappingDriver
             $filesIterator->append($iterator);
         }
 
-        $sourceFilePathNames = $this->pathNameIterator($filesIterator);
+        /** @var iterable<string> $sourceFilePathNames */
+        $sourceFilePathNames = $this->sourceFilePathNames ?? $this->pathNameIterator($filesIterator);
         $includedFiles       = [];
 
         foreach ($sourceFilePathNames as $sourceFile) {

--- a/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
+++ b/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
@@ -8,9 +8,9 @@ use Doctrine\Persistence\Mapping\MappingException;
 use FilesystemIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
-use RecursiveRegexIterator;
 use ReflectionClass;
 use RegexIterator;
+use SplFileInfo;
 
 use function array_merge;
 use function array_unique;
@@ -21,6 +21,7 @@ use function is_dir;
 use function preg_match;
 use function preg_quote;
 use function realpath;
+use function sprintf;
 use function str_contains;
 use function str_replace;
 
@@ -140,20 +141,22 @@ trait ColocatedMappingDriver
                 throw MappingException::fileMappingDriversRequireConfiguredDirectoryPath($path);
             }
 
+            /** @var iterable<SplFileInfo> $iterator */
             $iterator = new RegexIterator(
                 new RecursiveIteratorIterator(
                     new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
                     RecursiveIteratorIterator::LEAVES_ONLY,
                 ),
-                '/^.+' . preg_quote($this->fileExtension) . '$/i',
-                RecursiveRegexIterator::GET_MATCH,
+                sprintf('/%s$/', preg_quote($this->fileExtension, '/')),
+                RegexIterator::MATCH,
             );
 
             foreach ($iterator as $file) {
-                $sourceFile = $file[0];
+                $sourceFile = $file->getPathname();
 
                 if (preg_match('(^phar:)i', $sourceFile) === 0) {
                     $sourceFile = realpath($sourceFile);
+                    assert($sourceFile !== false);
                 }
 
                 foreach ($this->excludePaths as $excludePath) {

--- a/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
+++ b/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\Persistence\Mapping\Driver;
 
+use AppendIterator;
 use Doctrine\Persistence\Mapping\MappingException;
 use FilesystemIterator;
+use Generator;
+use Iterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionClass;
@@ -133,15 +136,15 @@ trait ColocatedMappingDriver
             throw MappingException::pathRequiredForDriver(static::class);
         }
 
-        $classes       = [];
-        $includedFiles = [];
+        /** @var AppendIterator<array-key,SplFileInfo,Iterator<array-key,SplFileInfo>> $filesIterator */
+        $filesIterator = new AppendIterator();
 
         foreach ($this->paths as $path) {
             if (! is_dir($path)) {
                 throw MappingException::fileMappingDriversRequireConfiguredDirectoryPath($path);
             }
 
-            /** @var iterable<SplFileInfo> $iterator */
+            /** @var Iterator<array-key,SplFileInfo> $iterator */
             $iterator = new RegexIterator(
                 new RecursiveIteratorIterator(
                     new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
@@ -151,31 +154,35 @@ trait ColocatedMappingDriver
                 RegexIterator::MATCH,
             );
 
-            foreach ($iterator as $file) {
-                $sourceFile = $file->getPathname();
-
-                if (preg_match('(^phar:)i', $sourceFile) === 0) {
-                    $sourceFile = realpath($sourceFile);
-                    assert($sourceFile !== false);
-                }
-
-                foreach ($this->excludePaths as $excludePath) {
-                    $realExcludePath = realpath($excludePath);
-                    assert($realExcludePath !== false);
-                    $exclude = str_replace('\\', '/', $realExcludePath);
-                    $current = str_replace('\\', '/', $sourceFile);
-
-                    if (str_contains($current, $exclude)) {
-                        continue 2;
-                    }
-                }
-
-                require_once $sourceFile;
-
-                $includedFiles[] = $sourceFile;
-            }
+            $filesIterator->append($iterator);
         }
 
+        $sourceFilePathNames = $this->pathNameIterator($filesIterator);
+        $includedFiles       = [];
+
+        foreach ($sourceFilePathNames as $sourceFile) {
+            if (preg_match('(^phar:)i', $sourceFile) === 0) {
+                $sourceFile = realpath($sourceFile);
+                assert($sourceFile !== false);
+            }
+
+            foreach ($this->excludePaths as $excludePath) {
+                $realExcludePath = realpath($excludePath);
+                assert($realExcludePath !== false);
+                $exclude = str_replace('\\', '/', $realExcludePath);
+                $current = str_replace('\\', '/', $sourceFile);
+
+                if (str_contains($current, $exclude)) {
+                    continue 2;
+                }
+            }
+
+            require_once $sourceFile;
+
+            $includedFiles[] = $sourceFile;
+        }
+
+        $classes  = [];
         $declared = get_declared_classes();
 
         foreach ($declared as $className) {
@@ -193,5 +200,17 @@ trait ColocatedMappingDriver
         $this->classNames = $classes;
 
         return $classes;
+    }
+
+    /**
+     * @param iterable<SplFileInfo> $filesIterator
+     *
+     * @return Generator<int,string>
+     */
+    private function pathNameIterator(iterable $filesIterator): Generator
+    {
+        foreach ($filesIterator as $file) {
+            yield $file->getPathname();
+        }
     }
 }

--- a/src/Persistence/Mapping/MappingException.php
+++ b/src/Persistence/Mapping/MappingException.php
@@ -30,7 +30,7 @@ class MappingException extends Exception
     public static function pathRequiredForDriver(string $driverClassName): self
     {
         return new self(sprintf(
-            'Specifying the paths to your entities is required when using %s to retrieve all class names.',
+            'Specifying source file paths to your entities is required when using %s to retrieve all class names.',
             $driverClassName,
         ));
     }

--- a/tests/Persistence/Mapping/ColocatedMappingDriverTest.php
+++ b/tests/Persistence/Mapping/ColocatedMappingDriverTest.php
@@ -13,13 +13,15 @@ use Doctrine\Tests\Persistence\Mapping\_files\colocated\TestClass;
 use Generator;
 use PHPUnit\Framework\TestCase;
 
+use function assert;
+use function is_array;
 use function sort;
 
 class ColocatedMappingDriverTest extends TestCase
 {
     public function testAddGetPaths(): void
     {
-        $driver = $this->createDriver(__DIR__ . '/_files/colocated');
+        $driver = $this->createPathDriver(__DIR__ . '/_files/colocated');
         self::assertSame([
             __DIR__ . '/_files/colocated',
         ], $driver->getPaths());
@@ -35,7 +37,7 @@ class ColocatedMappingDriverTest extends TestCase
 
     public function testAddGetExcludePaths(): void
     {
-        $driver = $this->createDriver(__DIR__ . '/_files/colocated');
+        $driver = $this->createPathDriver(__DIR__ . '/_files/colocated');
         self::assertSame([], $driver->getExcludePaths());
 
         $driver->addExcludePaths(['/test/path1', '/test/path2']);
@@ -48,7 +50,7 @@ class ColocatedMappingDriverTest extends TestCase
 
     public function testGetSetFileExtension(): void
     {
-        $driver = $this->createDriver(__DIR__ . '/_files/colocated');
+        $driver = $this->createPathDriver(__DIR__ . '/_files/colocated');
         self::assertSame('.php', $driver->getFileExtension());
 
         $driver->setFileExtension('.php1');
@@ -57,14 +59,26 @@ class ColocatedMappingDriverTest extends TestCase
     }
 
     /** @dataProvider pathProvider */
-    public function testGetAllClassNames(string $path): void
+    public function testGetAllClassNamesForPath(string $path): void
     {
-        $driver = $this->createDriver($path);
+        $driver = $this->createPathDriver($path);
 
         $classes = $driver->getAllClassNames();
 
         sort($classes);
         self::assertSame([Entity::class, EntityFixture::class], $classes);
+    }
+
+    public function testGetAllClassNamesForIterableFilePathNames(): void
+    {
+        $driver = $this->createFilePathNamesDriver([
+            __DIR__ . '/_files/colocated/Entity.php',
+            __DIR__ . '/_files/colocated/TestClass.php',
+        ]);
+
+        $classes = $driver->getAllClassNames();
+
+        self::assertSame([Entity::class], $classes, 'The driver should only return the class names from the provided file path names, excluding transient class names.');
     }
 
     /** @return Generator<string, array{string}> */
@@ -74,9 +88,15 @@ class ColocatedMappingDriverTest extends TestCase
         yield 'winding path' => [__DIR__ . '/../Mapping/_files/colocated'];
     }
 
-    private function createDriver(string $path): MyDriver
+    private function createPathDriver(string $path): MyDriver
     {
         return new MyDriver([$path]);
+    }
+
+    /** @param list<string> $paths */
+    private function createFilePathNamesDriver(array $paths): MyDriver
+    {
+        return new MyDriver($paths, true);
     }
 }
 
@@ -84,10 +104,16 @@ final class MyDriver implements MappingDriver
 {
     use ColocatedMappingDriver;
 
-    /** @param non-empty-list<string> $paths One or multiple paths where mapping classes can be found. */
-    public function __construct(array $paths)
+    /** @param iterable<string> $paths Source file path names */
+    public function __construct(iterable $paths, bool $sourceFilePathNames = false)
     {
-        $this->addPaths($paths);
+        if (! $sourceFilePathNames) {
+            assert(is_array($paths));
+
+            $this->addPaths($paths);
+        } else {
+            $this->sourceFilePathNames = $paths;
+        }
     }
 
     /**

--- a/tests/Persistence/Mapping/ColocatedMappingDriverTest.php
+++ b/tests/Persistence/Mapping/ColocatedMappingDriverTest.php
@@ -7,11 +7,13 @@ namespace Doctrine\Tests\Persistence\Mapping;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\ColocatedMappingDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
-use Doctrine\TestClass;
+use Doctrine\Tests\Persistence\Mapping\_files\colocated\Entity;
+use Doctrine\Tests\Persistence\Mapping\_files\colocated\EntityFixture;
+use Doctrine\Tests\Persistence\Mapping\_files\colocated\TestClass;
 use Generator;
 use PHPUnit\Framework\TestCase;
 
-use function array_values;
+use function sort;
 
 class ColocatedMappingDriverTest extends TestCase
 {
@@ -61,7 +63,8 @@ class ColocatedMappingDriverTest extends TestCase
 
         $classes = $driver->getAllClassNames();
 
-        self::assertSame([TestClass::class], $classes);
+        sort($classes);
+        self::assertSame([Entity::class, EntityFixture::class], $classes);
     }
 
     /** @return Generator<string, array{string}> */
@@ -73,7 +76,7 @@ class ColocatedMappingDriverTest extends TestCase
 
     private function createDriver(string $path): MyDriver
     {
-        return new MyDriver($path);
+        return new MyDriver([$path]);
     }
 }
 
@@ -81,10 +84,10 @@ final class MyDriver implements MappingDriver
 {
     use ColocatedMappingDriver;
 
-    /** @param string ...$paths One or multiple paths where mapping classes can be found. */
-    public function __construct(string ...$paths)
+    /** @param non-empty-list<string> $paths One or multiple paths where mapping classes can be found. */
+    public function __construct(array $paths)
     {
-        $this->addPaths(array_values($paths));
+        $this->addPaths($paths);
     }
 
     /**
@@ -96,6 +99,6 @@ final class MyDriver implements MappingDriver
 
     public function isTransient(string $className): bool
     {
-        return $className !== TestClass::class;
+        return $className === TestClass::class;
     }
 }

--- a/tests/Persistence/Mapping/_files/colocated/Entity.php
+++ b/tests/Persistence/Mapping/_files/colocated/Entity.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Persistence\Mapping\_files\colocated;
+
+/**
+ * The driver should include this file and return its class name
+ * from {@see \Doctrine\Persistence\Mapping\Driver\ColocatedMappingDriver::getAllClassNames()} method.
+ */
+class Entity
+{
+}

--- a/tests/Persistence/Mapping/_files/colocated/EntityFixture.php
+++ b/tests/Persistence/Mapping/_files/colocated/EntityFixture.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Persistence\Mapping\_files\colocated;
+
+/**
+ * This class is in the same directory as {@see Entity},
+ * therefore, it's included when using an ordinary path scanning mechanism.
+ */
+class EntityFixture
+{
+}

--- a/tests/Persistence/Mapping/_files/colocated/Foo.mphp
+++ b/tests/Persistence/Mapping/_files/colocated/Foo.mphp
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Persistence\Mapping\_files\colocated;
+
+/**
+ * This file has a .mphp extension, and its presence verifies
+ * that preg_quote() is actually called on the file extension.
+ * Thus, it never reaches the driver as it only uses .php extension.
+ */
+final class Foo
+{
+}

--- a/tests/Persistence/Mapping/_files/colocated/TestClass.php
+++ b/tests/Persistence/Mapping/_files/colocated/TestClass.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Doctrine;
+namespace Doctrine\Tests\Persistence\Mapping\_files\colocated;
 
+/**
+ * This class is considered transient {@see \Doctrine\Persistence\Mapping\Driver\ColocatedMappingDriver::isTransient()}
+ * by the driver, and therefore its class name is not returned.
+ */
 class TestClass
-{
-}
-
-class Entity
 {
 }


### PR DESCRIPTION
This PR follows from https://github.com/doctrine/persistence/pull/424.

It aims to rework `ColocatedMappingDriver` so that it won't have the responsibility of scanning for files in the provided directories, but will instead accept an iterable of source file path names. Thus, every individual component using `ColocatedMappingDriver` should provide a complete iterator that covers all files.

Ultimately, Symfony Finder should be used to grab a list of PHP files that must be mapped. This aims for more flexibility regarding file scanning, so that users would be able to customize what files to include.