### PR TITLE
Fix: prevent `$sourceFilePathNames` from shadowing retroactively adde…

### DIFF
--- a/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
+++ b/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
@@ -19,7 +19,6 @@ use function array_merge;
 use function array_unique;
 use function assert;
 use function get_declared_classes;
-use function in_array;
 use function is_dir;
 use function preg_match;
 use function preg_quote;
@@ -165,7 +164,8 @@ trait ColocatedMappingDriver
             $this->sourceFilePathNames ?? [],
             $this->pathNameIterator($filesIterator),
         );
-        $includedFiles       = [];
+        /** @var array<string,true> $includedFiles */
+        $includedFiles = [];
 
         foreach ($sourceFilePathNames as $sourceFile) {
             if (preg_match('(^phar:)i', $sourceFile) === 0) {
@@ -186,7 +186,7 @@ trait ColocatedMappingDriver
 
             require_once $sourceFile;
 
-            $includedFiles[] = $sourceFile;
+            $includedFiles[$sourceFile] = true;
         }
 
         $classes  = [];
@@ -197,7 +197,7 @@ trait ColocatedMappingDriver
 
             $sourceFile = $rc->getFileName();
 
-            if (! in_array($sourceFile, $includedFiles, true) || $this->isTransient($className)) {
+            if (! isset($includedFiles[$sourceFile]) || $this->isTransient($className)) {
                 continue;
             }
 

--- a/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
+++ b/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
@@ -161,7 +161,10 @@ trait ColocatedMappingDriver
         }
 
         /** @var iterable<string> $sourceFilePathNames */
-        $sourceFilePathNames = $this->sourceFilePathNames ?? $this->pathNameIterator($filesIterator);
+        $sourceFilePathNames = $this->mergeIterables(
+            $this->sourceFilePathNames ?? [],
+            $this->pathNameIterator($filesIterator),
+        );
         $includedFiles       = [];
 
         foreach ($sourceFilePathNames as $sourceFile) {
@@ -216,5 +219,20 @@ trait ColocatedMappingDriver
         foreach ($filesIterator as $file) {
             yield $file->getPathname();
         }
+    }
+
+    /**
+     * @param iterable<TKey, T> $iterable1
+     * @param iterable<TKey, T> $iterable2
+     *
+     * @return Generator<TKey, T>
+     *
+     * @template TKey
+     * @template T
+     */
+    private function mergeIterables(iterable $iterable1, iterable $iterable2): Generator
+    {
+        yield from $iterable1;
+        yield from $iterable2;
     }
 }

--- a/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
+++ b/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
@@ -162,7 +162,7 @@ trait ColocatedMappingDriver
         /** @var iterable<string> $sourceFilePathNames */
         $sourceFilePathNames = $this->mergeIterables(
             $this->sourceFilePathNames ?? [],
-            $this->pathNameIterator($filesIterator),
+            new PathNameIterator($filesIterator),
         );
         /** @var array<string,true> $includedFiles */
         $includedFiles = [];
@@ -207,18 +207,6 @@ trait ColocatedMappingDriver
         $this->classNames = $classes;
 
         return $classes;
-    }
-
-    /**
-     * @param iterable<SplFileInfo> $filesIterator
-     *
-     * @return Generator<int,string>
-     */
-    private function pathNameIterator(iterable $filesIterator): Generator
-    {
-        foreach ($filesIterator as $file) {
-            yield $file->getPathname();
-        }
     }
 
     /**

--- a/src/Persistence/Mapping/Driver/PathNameIterator.php
+++ b/src/Persistence/Mapping/Driver/PathNameIterator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Persistence\Mapping\Driver;
+
+use Generator;
+use IteratorAggregate;
+use SplFileInfo;
+
+/** @implements IteratorAggregate<int,string> */
+final class PathNameIterator implements IteratorAggregate
+{
+    public function __construct(
+        /** @var iterable<SplFileInfo> */
+        private readonly iterable $filesIterator,
+    ) {
+    }
+
+    /** @return Generator<int,string> */
+    public function getIterator(): Generator
+    {
+        foreach ($this->filesIterator as $file) {
+            yield $file->getPathname();
+        }
+    }
+}

--- a/tests/Persistence/Mapping/ColocatedMappingDriverTest.php
+++ b/tests/Persistence/Mapping/ColocatedMappingDriverTest.php
@@ -81,6 +81,22 @@ class ColocatedMappingDriverTest extends TestCase
         self::assertSame([Entity::class], $classes, 'The driver should only return the class names from the provided file path names, excluding transient class names.');
     }
 
+    public function testGetAllClassNamesWorksForBothIterableFilePathNamesAndRetroactivelyAddedDirectoryPaths(): void
+    {
+        $driver = $this->createFilePathNamesDriver([__DIR__ . '/_files/colocated/Entity.php']);
+
+        $driver->addPaths([__DIR__ . '/_files/colocated/']);
+
+        $classes = $driver->getAllClassNames();
+        sort($classes);
+
+        self::assertSame(
+            [Entity::class, EntityFixture::class],
+            $classes,
+            'The driver should return class names from both the provided file path names and the retroactively added directory paths (these should not be ignored).',
+        );
+    }
+
     /** @return Generator<string, array{string}> */
     public static function pathProvider(): Generator
     {


### PR DESCRIPTION
This PR fixes a possible bug introduced after https://github.com/doctrine/persistence/pull/429/

If the client code had called `addPaths()` after the instance creation, it would've been ignored (without any warning or so), and paths would not have been used. This commit fixes that. Retroactively added paths will be taken into account as well as `$sourceFilePathNames`.