### PR TITLE
Revert "Feature: allow `ColocatedMappingDriver` to accept iterable source file path names

### DIFF
--- a/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
+++ b/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php
@@ -33,9 +33,6 @@ use function str_replace;
  */
 trait ColocatedMappingDriver
 {
-    /** @var iterable<string> */
-    private iterable $sourceFilePathNames;
-
     /**
      * The paths where to look for mapping files.
      *
@@ -54,7 +51,7 @@ trait ColocatedMappingDriver
     protected string $fileExtension = '.php';
 
     /**
-     * Cache for {@see getAllClassNames()}.
+     * Cache for getAllClassNames().
      *
      * @var array<int, string>|null
      * @phpstan-var list<class-string>|null
@@ -82,7 +79,7 @@ trait ColocatedMappingDriver
     }
 
     /**
-     * Append exclude lookup paths to a metadata driver.
+     * Append exclude lookup paths to metadata driver.
      *
      * @param string[] $paths
      */
@@ -135,7 +132,7 @@ trait ColocatedMappingDriver
             return $this->classNames;
         }
 
-        if ($this->paths === [] && ! isset($this->sourceFilePathNames)) {
+        if ($this->paths === []) {
             throw MappingException::pathRequiredForDriver(static::class);
         }
 
@@ -160,8 +157,7 @@ trait ColocatedMappingDriver
             $filesIterator->append($iterator);
         }
 
-        /** @var iterable<string> $sourceFilePathNames */
-        $sourceFilePathNames = $this->sourceFilePathNames ?? $this->pathNameIterator($filesIterator);
+        $sourceFilePathNames = $this->pathNameIterator($filesIterator);
         $includedFiles       = [];
 
         foreach ($sourceFilePathNames as $sourceFile) {

--- a/src/Persistence/Mapping/MappingException.php
+++ b/src/Persistence/Mapping/MappingException.php
@@ -30,7 +30,7 @@ class MappingException extends Exception
     public static function pathRequiredForDriver(string $driverClassName): self
     {
         return new self(sprintf(
-            'Specifying source file paths to your entities is required when using %s to retrieve all class names.',
+            'Specifying the paths to your entities is required when using %s to retrieve all class names.',
             $driverClassName,
         ));
     }

--- a/tests/Persistence/Mapping/ColocatedMappingDriverTest.php
+++ b/tests/Persistence/Mapping/ColocatedMappingDriverTest.php
@@ -13,15 +13,13 @@ use Doctrine\Tests\Persistence\Mapping\_files\colocated\TestClass;
 use Generator;
 use PHPUnit\Framework\TestCase;
 
-use function assert;
-use function is_array;
 use function sort;
 
 class ColocatedMappingDriverTest extends TestCase
 {
     public function testAddGetPaths(): void
     {
-        $driver = $this->createPathDriver(__DIR__ . '/_files/colocated');
+        $driver = $this->createDriver(__DIR__ . '/_files/colocated');
         self::assertSame([
             __DIR__ . '/_files/colocated',
         ], $driver->getPaths());
@@ -37,7 +35,7 @@ class ColocatedMappingDriverTest extends TestCase
 
     public function testAddGetExcludePaths(): void
     {
-        $driver = $this->createPathDriver(__DIR__ . '/_files/colocated');
+        $driver = $this->createDriver(__DIR__ . '/_files/colocated');
         self::assertSame([], $driver->getExcludePaths());
 
         $driver->addExcludePaths(['/test/path1', '/test/path2']);
@@ -50,7 +48,7 @@ class ColocatedMappingDriverTest extends TestCase
 
     public function testGetSetFileExtension(): void
     {
-        $driver = $this->createPathDriver(__DIR__ . '/_files/colocated');
+        $driver = $this->createDriver(__DIR__ . '/_files/colocated');
         self::assertSame('.php', $driver->getFileExtension());
 
         $driver->setFileExtension('.php1');
@@ -59,26 +57,14 @@ class ColocatedMappingDriverTest extends TestCase
     }
 
     /** @dataProvider pathProvider */
-    public function testGetAllClassNamesForPath(string $path): void
+    public function testGetAllClassNames(string $path): void
     {
-        $driver = $this->createPathDriver($path);
+        $driver = $this->createDriver($path);
 
         $classes = $driver->getAllClassNames();
 
         sort($classes);
         self::assertSame([Entity::class, EntityFixture::class], $classes);
-    }
-
-    public function testGetAllClassNamesForIterableFilePathNames(): void
-    {
-        $driver = $this->createFilePathNamesDriver([
-            __DIR__ . '/_files/colocated/Entity.php',
-            __DIR__ . '/_files/colocated/TestClass.php',
-        ]);
-
-        $classes = $driver->getAllClassNames();
-
-        self::assertSame([Entity::class], $classes, 'The driver should only return the class names from the provided file path names, excluding transient class names.');
     }
 
     /** @return Generator<string, array{string}> */
@@ -88,15 +74,9 @@ class ColocatedMappingDriverTest extends TestCase
         yield 'winding path' => [__DIR__ . '/../Mapping/_files/colocated'];
     }
 
-    private function createPathDriver(string $path): MyDriver
+    private function createDriver(string $path): MyDriver
     {
         return new MyDriver([$path]);
-    }
-
-    /** @param list<string> $paths */
-    private function createFilePathNamesDriver(array $paths): MyDriver
-    {
-        return new MyDriver($paths, true);
     }
 }
 
@@ -104,16 +84,10 @@ final class MyDriver implements MappingDriver
 {
     use ColocatedMappingDriver;
 
-    /** @param iterable<string> $paths Source file path names */
-    public function __construct(iterable $paths, bool $sourceFilePathNames = false)
+    /** @param non-empty-list<string> $paths One or multiple paths where mapping classes can be found. */
+    public function __construct(array $paths)
     {
-        if (! $sourceFilePathNames) {
-            assert(is_array($paths));
-
-            $this->addPaths($paths);
-        } else {
-            $this->sourceFilePathNames = $paths;
-        }
+        $this->addPaths($paths);
     }
 
     /**


### PR DESCRIPTION
This reverts commit a6cb5a1dc910b7804dd80633483fcd0e40e1fde6. A better implementation is incoming, with fixes. This reverts makes the branch releaseable again, and will make the incoming pull request easier to review.

Closes #430 