### PR TITLE
Fix `MappingDriverChain` namespace matching

### DIFF
--- a/src/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/src/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -8,6 +8,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\MappingException;
 
 use function array_keys;
+use function rtrim;
 use function spl_object_hash;
 use function strpos;
 
@@ -73,7 +74,7 @@ class MappingDriverChain implements MappingDriver
     public function loadMetadataForClass(string $className, ClassMetadata $metadata)
     {
         foreach ($this->drivers as $namespace => $driver) {
-            if (strpos($className, $namespace) === 0) {
+            if ($this->isInNamespace($className, $namespace)) {
                 $driver->loadMetadataForClass($className, $metadata);
 
                 return;
@@ -105,7 +106,7 @@ class MappingDriverChain implements MappingDriver
             }
 
             foreach ($driverClasses[$oid] as $className) {
-                if (strpos($className, $namespace) !== 0) {
+                if (! $this->isInNamespace($className, $namespace)) {
                     continue;
                 }
 
@@ -128,7 +129,7 @@ class MappingDriverChain implements MappingDriver
     public function isTransient(string $className)
     {
         foreach ($this->drivers as $namespace => $driver) {
-            if (strpos($className, $namespace) === 0) {
+            if ($this->isInNamespace($className, $namespace)) {
                 return $driver->isTransient($className);
             }
         }
@@ -138,5 +139,12 @@ class MappingDriverChain implements MappingDriver
         }
 
         return true;
+    }
+
+    private function isInNamespace(string $className, string $namespace): bool
+    {
+        $namespace = rtrim($namespace, '\\') . '\\';
+
+        return strpos($className, $namespace) === 0;
     }
 }

--- a/tests/Persistence/Mapping/DriverChainTest.php
+++ b/tests/Persistence/Mapping/DriverChainTest.php
@@ -15,7 +15,11 @@ use stdClass;
 
 class DriverChainTest extends DoctrineTestCase
 {
-    public function testDelegateToMatchingNamespaceDriver(): void
+    /**
+     * @testWith ["Doctrine\\Tests\\Models\\Company"]
+     *           ["Doctrine\\Tests\\Persistence\\Map"]
+     */
+    public function testDelegateToMatchingNamespaceDriver(string $namespace): void
     {
         $className     = DriverChainEntity::class;
         $classMetadata = $this->createMock(ClassMetadata::class);
@@ -37,7 +41,7 @@ class DriverChainTest extends DoctrineTestCase
                 ->with(self::equalTo($className))
                 ->willReturn(true);
 
-        $chain->addDriver($driver1, 'Doctrine\Tests\Models\Company');
+        $chain->addDriver($driver1, $namespace);
         $chain->addDriver($driver2, 'Doctrine\Tests\Persistence\Mapping');
 
         $chain->loadMetadataForClass($className, $classMetadata);


### PR DESCRIPTION
When I tried using multiple entity managers, I encountered an issue where the manager registry returned the wrong entity manager.

The root cause was how the `MappingDriverChain` checks whether an entity belongs to a given namespace.

In my setup, I have two namespaces: `App\Entity` and `App\EntityUser`. Since `App\EntityUser\SomeEntity` starts with `App\Entity`, it was incorrectly matched, causing the wrong entity manager to be selected.