### PR TITLE
Remove entry for 1.4

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -84,11 +84,6 @@
             "maintained": false
         },
         {
-            "name": "1.4",
-            "slug": "1.4",
-            "maintained": false
-        },
-        {
             "name": "1.3",
             "slug": "1.3",
             "maintained": false


### PR DESCRIPTION
It does not have tags, so removing the branchName in 57d1bddf7a1b3ff7f164f370c841eb7f43c8b033 broke the build.

Anyway, the goal was to drop the old branch names, so let us drop this entry.