### PR TITLE
Support closure returned by `.php` files in the `PHPDriver`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,31 @@ The interface `Doctrine\Persistence\Mapping\ClassMetadata` has two new methods:
 
 Not implementing these methods is deprecated. They will be required in 5.0.
 
+## Deprecated modifying `$metadata` in PHP mapping files
+
+Relying on the `$metadata` variable directly in PHP mapping files is deprecated.
+Instead, wrap the code in a closure that is returned by the configuration file.
+
+Before:
+
+```php
+<?php // mappings/App.Entity.User.php
+
+$metadata->name = \App\Entity\User::class;
+```
+
+After:
+
+```php
+<?php // mappings/App.Entity.User.php
+
+use Doctrine\Persistence\Mapping\ClassMetadata;
+
+return function (ClassMetadata $metadata): void {
+    $metadata->name = \App\Entity\User::class;
+};
+```
+
 # Upgrade to 4.0
 
 ## BC Break: Removed `StaticReflectionService`

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     ],
     "require": {
         "php": "^8.1",
+        "doctrine/deprecations": "^1",
         "doctrine/event-manager": "^1 || ^2",
         "psr/cache": "^1.0 || ^2.0 || ^3.0"
     },

--- a/docs/en/reference/index.rst
+++ b/docs/en/reference/index.rst
@@ -258,10 +258,15 @@ mapping metadata.
 .. code-block:: php
 
     use App\Model\User;
+    use Doctrine\Persistence\Mapping\ClassMetadata;
 
-    $metadata->name = User::class;
+    return function (ClassMetadata $metadata): void {
+        $metadata->name = User::class;
 
-    // ...
+        // ...
+
+    };
+
 
 StaticPHPDriver
 --------------
@@ -283,6 +288,8 @@ Your class in ``App\Model\User`` would look like the following.
 .. code-block:: php
 
     namespace App\Model;
+
+    use Doctrine\Persistence\Mapping\ClassMetadata;
 
     final class User
     {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,7 +14,7 @@ parameters:
         - tests/Persistence/Mapping/_files/colocated/Foo.mphp
 
     excludePaths:
-        - tests/Persistence/Mapping/_files/Doctrine.Tests.Persistence.Mapping.PHPTestEntity.php
+        - tests/Persistence/Mapping/_files/Doctrine.*.php
 
     ignoreErrors:
         - '#Variable property access on \$this\(Doctrine\\Persistence\\Reflection\\TypedNoDefaultReflectionProperty\)\.#'

--- a/src/Persistence/Mapping/Driver/PHPDriver.php
+++ b/src/Persistence/Mapping/Driver/PHPDriver.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\Persistence\Mapping\Driver;
 
+use Closure;
+use CompileError;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\Persistence\Mapping\ClassMetadata;
+use Error;
 
 /**
  * The PHPDriver includes php files which just populate ClassMetadataInfo
@@ -35,6 +39,33 @@ class PHPDriver extends FileDriver
      */
     protected function loadMappingFile(string $file): array
     {
+        try {
+            $callback = Closure::bind(static function (string $file): mixed {
+                $metadata = null;
+
+                return include $file;
+            }, null, null)($file);
+        } catch (CompileError $e) {
+            throw $e;
+        } catch (Error) {
+            // Calling any method on $metadata=null will raise an Error
+            // Falling back to legacy behavior of expecting $metadata to be populated
+            $callback = null;
+        }
+
+        if ($callback instanceof Closure) {
+            $callback($this->metadata);
+
+            return [$this->metadata->getName() => $this->metadata];
+        }
+
+        Deprecation::trigger(
+            'doctrine/persistence',
+            'https://github.com/doctrine/persistence/pull/450',
+            'Not returning a Closure from a PHP mapping file is deprecated',
+        );
+
+        unset($callback);
         $metadata = $this->metadata;
         include $file;
 

--- a/tests/Persistence/Mapping/PHPDriverTest.php
+++ b/tests/Persistence/Mapping/PHPDriverTest.php
@@ -4,22 +4,80 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Persistence\Mapping;
 
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\PHPDriver;
 use Doctrine\Tests\DoctrineTestCase;
+use Error;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\TestWith;
 
 class PHPDriverTest extends DoctrineTestCase
 {
-    public function testLoadMetadata(): void
+    use VerifyDeprecations;
+
+    /** @phpstan-param class-string $className */
+    #[IgnoreDeprecations]
+    #[TestWith([PHPTestEntity::class])]
+    #[TestWith([PHPTestEntityAssert::class])]
+    public function testLoadMetadata(string $className): void
+    {
+        $metadata = $this->createMock(ClassMetadata::class);
+        $metadata->expects(self::once())->method('getFieldNames');
+        $driver = new PHPDriver([__DIR__ . '/_files']);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/persistence/pull/450');
+        $driver->loadMetadataForClass($className, $metadata);
+    }
+
+    public function testLoadMetadataWithClosure(): void
     {
         $metadata = $this->createMock(ClassMetadata::class);
         $metadata->expects(self::once())->method('getFieldNames');
 
         $driver = new PHPDriver([__DIR__ . '/_files']);
-        $driver->loadMetadataForClass(PHPTestEntity::class, $metadata);
+        $driver->loadMetadataForClass(PHPTestEntityClosure::class, $metadata);
+    }
+
+    public function testLoadMetadataClosureNotBoundToObject(): void
+    {
+        $metadata = $this->createMock(ClassMetadata::class);
+        $driver   = new PHPDriver([__DIR__ . '/_files']);
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Using $this when not in object context');
+
+        $driver->loadMetadataForClass(PHPTestIncorrectUseThis::class, $metadata);
+    }
+
+    public function testLoadMetadataClosureNotBoundToClass(): void
+    {
+        $metadata = $this->createMock(ClassMetadata::class);
+        $driver   = new PHPDriver([__DIR__ . '/_files']);
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Cannot use "static" in the global scope');
+
+        $driver->loadMetadataForClass(PHPTestIncorrectUseStatic::class, $metadata);
     }
 }
 
 class PHPTestEntity
+{
+}
+
+class PHPTestEntityAssert
+{
+}
+
+class PHPTestEntityClosure
+{
+}
+
+class PHPTestIncorrectUseThis
+{
+}
+
+class PHPTestIncorrectUseStatic
 {
 }

--- a/tests/Persistence/Mapping/_files/Doctrine.Tests.Persistence.Mapping.PHPTestEntityAssert.php
+++ b/tests/Persistence/Mapping/_files/Doctrine.Tests.Persistence.Mapping.PHPTestEntityAssert.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\Persistence\Mapping\ClassMetadata;
+
+assert($metadata instanceof ClassMetadata);
+$metadata->getFieldNames();

--- a/tests/Persistence/Mapping/_files/Doctrine.Tests.Persistence.Mapping.PHPTestEntityClosure.php
+++ b/tests/Persistence/Mapping/_files/Doctrine.Tests.Persistence.Mapping.PHPTestEntityClosure.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\Persistence\Mapping\ClassMetadata;
+
+return static function (ClassMetadata $metadata): void {
+    $metadata->getFieldNames();
+};

--- a/tests/Persistence/Mapping/_files/Doctrine.Tests.Persistence.Mapping.PHPTestIncorrectUseStatic.php
+++ b/tests/Persistence/Mapping/_files/Doctrine.Tests.Persistence.Mapping.PHPTestIncorrectUseStatic.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\Persistence\Mapping\ClassMetadata;
+
+return static function (ClassMetadata $metadata): void {
+    $metadata->isIdentifier(static::class);
+};

--- a/tests/Persistence/Mapping/_files/Doctrine.Tests.Persistence.Mapping.PHPTestIncorrectUseThis.php
+++ b/tests/Persistence/Mapping/_files/Doctrine.Tests.Persistence.Mapping.PHPTestIncorrectUseThis.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return function (): void {
+    $this->setGlobalBasename('global-mapping');
+};


### PR DESCRIPTION
The [`PHPDriver`](https://github.com/doctrine/persistence/blob/eca73be1a33892e09baa6ec3d7c4fcbfd4cb5dcb/src/Persistence/Mapping/Driver/PHPDriver.php#L36-L42) use an undocumented `$metadata` variable when loading the files.
Example: https://github.com/doctrine/orm/blob/3.5.x/tests/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Upsertable.Updatable.php

The idea is to accept a closure with a typed parameter, and prevent access to the loader with `$this`.

This is inspired by the way [loaders work in Symfony](https://github.com/symfony/symfony/blob/1b94288404e5555190f3c995324cfe3db6f3651d/src/Symfony/Component/Routing/Loader/PhpFileLoader.php#L46-L48).