### PR TITLE
Revert `MappingDriverChain` namespace matching fix

### DIFF
--- a/src/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/src/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -8,7 +8,6 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\MappingException;
 
 use function array_keys;
-use function rtrim;
 use function spl_object_hash;
 use function strpos;
 
@@ -74,7 +73,7 @@ class MappingDriverChain implements MappingDriver
     public function loadMetadataForClass(string $className, ClassMetadata $metadata)
     {
         foreach ($this->drivers as $namespace => $driver) {
-            if ($this->isInNamespace($className, $namespace)) {
+            if (strpos($className, $namespace) === 0) {
                 $driver->loadMetadataForClass($className, $metadata);
 
                 return;
@@ -106,7 +105,7 @@ class MappingDriverChain implements MappingDriver
             }
 
             foreach ($driverClasses[$oid] as $className) {
-                if (! $this->isInNamespace($className, $namespace)) {
+                if (strpos($className, $namespace) !== 0) {
                     continue;
                 }
 
@@ -129,7 +128,7 @@ class MappingDriverChain implements MappingDriver
     public function isTransient(string $className)
     {
         foreach ($this->drivers as $namespace => $driver) {
-            if ($this->isInNamespace($className, $namespace)) {
+            if (strpos($className, $namespace) === 0) {
                 return $driver->isTransient($className);
             }
         }
@@ -139,12 +138,5 @@ class MappingDriverChain implements MappingDriver
         }
 
         return true;
-    }
-
-    private function isInNamespace(string $className, string $namespace): bool
-    {
-        $namespace = rtrim($namespace, '\\') . '\\';
-
-        return strpos($className, $namespace) === 0;
     }
 }

--- a/tests/Persistence/Mapping/DriverChainTest.php
+++ b/tests/Persistence/Mapping/DriverChainTest.php
@@ -16,10 +16,10 @@ use stdClass;
 class DriverChainTest extends DoctrineTestCase
 {
     /**
-     * @testWith ["Doctrine\\Tests\\Models\\Company"]
-     *           ["Doctrine\\Tests\\Persistence\\Map"]
+     * @testWith ["Doctrine\\Tests\\Models\\Company", "Doctrine\\Tests\\Persistence\\Mapping"]
+     *           ["Doctrine\\Tests\\Persistence\\Map\\", "Doctrine\\Tests\\Persistence\\Map"]
      */
-    public function testDelegateToMatchingNamespaceDriver(string $namespace): void
+    public function testDelegateToMatchingNamespaceDriver(string $namespace1, string $namespace2): void
     {
         $className     = DriverChainEntity::class;
         $classMetadata = $this->createMock(ClassMetadata::class);
@@ -41,8 +41,8 @@ class DriverChainTest extends DoctrineTestCase
                 ->with(self::equalTo($className))
                 ->willReturn(true);
 
-        $chain->addDriver($driver1, $namespace);
-        $chain->addDriver($driver2, 'Doctrine\Tests\Persistence\Mapping');
+        $chain->addDriver($driver1, $namespace1);
+        $chain->addDriver($driver2, $namespace2);
 
         $chain->loadMetadataForClass($className, $classMetadata);
 


### PR DESCRIPTION
Reverts #448

As [reported](https://github.com/doctrine/persistence/pull/448#issuecomment-3421838130), the previous PR introduced an unforeseen BC break.

This PR reverts those changes and adds a simple test to prevent regression.

cc @GromNaN @DarkLuk42 