### PR TITLE
Make `AbstractManagerRegistry::$proxyInterfaceName` nullable

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -41,6 +41,11 @@ return function (ClassMetadata $metadata): void {
 };
 ```
 
+## Do not pass any proxy interface to `AbstractManagerRegistry` when using native proxies
+
+With PHP 8.4 native lazy objects, you don't need to pass any proxy interface to
+`AbstractManagerRegistry`. The class of the lazy objects is the class being mapped.
+
 # Upgrade to 4.0
 
 ## BC Break: Removed `StaticReflectionService`

--- a/src/AbstractManagerRegistry.php
+++ b/src/AbstractManagerRegistry.php
@@ -18,7 +18,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * @param array<string, string> $connections
      * @param array<string, string> $managers
-     * @phpstan-param class-string $proxyInterfaceName
+     * @phpstan-param class-string|null $proxyInterfaceName Set to null when native lazy objects are used.
      */
     public function __construct(
         private readonly string $name,
@@ -26,7 +26,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
         private array $managers,
         private readonly string $defaultConnection,
         private readonly string $defaultManager,
-        private readonly string $proxyInterfaceName,
+        private readonly string|null $proxyInterfaceName = null,
     ) {
     }
 
@@ -127,19 +127,21 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
 
     public function getManagerForClass(string $class): ObjectManager|null
     {
-        $proxyClass = new ReflectionClass($class);
-        if ($proxyClass->isAnonymous()) {
-            return null;
-        }
-
-        if ($proxyClass->implementsInterface($this->proxyInterfaceName)) {
-            $parentClass = $proxyClass->getParentClass();
-
-            if ($parentClass === false) {
+        if ($this->proxyInterfaceName !== null) {
+            $proxyClass = new ReflectionClass($class);
+            if ($proxyClass->isAnonymous()) {
                 return null;
             }
 
-            $class = $parentClass->getName();
+            if ($proxyClass->implementsInterface($this->proxyInterfaceName)) {
+                $parentClass = $proxyClass->getParentClass();
+
+                if ($parentClass === false) {
+                    return null;
+                }
+
+                $class = $parentClass->getName();
+            }
         }
 
         foreach ($this->managers as $id) {

--- a/tests/ManagerRegistryTest.php
+++ b/tests/ManagerRegistryTest.php
@@ -45,6 +45,22 @@ class ManagerRegistryTest extends TestCase
         );
     }
 
+    public function testGetManagerForClassAnonymous(): void
+    {
+        $anonymousClass = new class extends TestObject implements Proxy {
+            public function __isInitialized(): bool
+            {
+                return true;
+            }
+
+            public function __load(): void
+            {
+            }
+        };
+
+        self::assertNull($this->mr->getManagerForClass($anonymousClass::class));
+    }
+
     public function testGetManagerForProxiedClass(): void
     {
         self::assertInstanceOf(
@@ -62,6 +78,39 @@ class ManagerRegistryTest extends TestCase
     {
         self::assertNull($this->mr->getManagerForClass((new class {
         })::class));
+    }
+
+    public function testGetManagerForWithoutProxyInterface(): void
+    {
+        $mr = new TestManagerRegistry(
+            'ORM',
+            ['default' => 'default_connection'],
+            ['default' => 'default_manager'],
+            'default',
+            'default',
+            null,
+            $this->getManagerFactory(),
+        );
+
+        self::assertInstanceOf(
+            ObjectManager::class,
+            $mr->getManagerForClass(TestObject::class),
+        );
+
+        self::assertNull($mr->getManagerForClass(TestObjectProxy::class));
+
+        $anonymousClass = new class extends TestObject implements Proxy {
+            public function __isInitialized(): bool
+            {
+                return true;
+            }
+
+            public function __load(): void
+            {
+            }
+        };
+
+        self::assertNull($mr->getManagerForClass($anonymousClass::class));
     }
 
     public function testResetManager(): void
@@ -179,7 +228,7 @@ class TestManagerRegistry extends AbstractManagerRegistry
     /**
      * {@inheritDoc}
      *
-     * @phpstan-param class-string $proxyInterfaceName
+     * @phpstan-param class-string|null $proxyInterfaceName
      */
     public function __construct(
         string $name,
@@ -187,7 +236,7 @@ class TestManagerRegistry extends AbstractManagerRegistry
         array $managers,
         string $defaultConnection,
         string $defaultManager,
-        string $proxyInterfaceName,
+        string|null $proxyInterfaceName,
         callable $managerFactory,
     ) {
         $this->managerFactory = $managerFactory;


### PR DESCRIPTION
When native lazy objects are used, there is no proxy class wrapping the entity/document class.