### PR TITLE
Deprecate `Proxy` interface and related

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## Deprecate `Proxy` and `ProxyClassNameResolver` interfaces
+
+Use native lazy objects instead of proxy classes for lazy objects.
+Don't use the `Doctrine\Persistence\Proxy` interface to identify lazy objects.
+Remove implementations and usages of the `ProxyClassNameResolver`. Native lazy
+objects have the same class.
+
 ## BC Break: added type declarations to constants
 
 The code base now has constants with type declarations. If you extend types

--- a/src/AbstractManagerRegistry.php
+++ b/src/AbstractManagerRegistry.php
@@ -18,7 +18,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * @param array<string, string> $connections
      * @param array<string, string> $managers
-     * @phpstan-param class-string $proxyInterfaceName
+     * @phpstan-param class-string|null $proxyInterfaceName
      */
     public function __construct(
         private readonly string $name,
@@ -26,7 +26,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
         private array $managers,
         private readonly string $defaultConnection,
         private readonly string $defaultManager,
-        private readonly string $proxyInterfaceName,
+        private readonly string|null $proxyInterfaceName = null,
     ) {
     }
 
@@ -132,7 +132,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
             return null;
         }
 
-        if ($proxyClass->implementsInterface($this->proxyInterfaceName)) {
+        if ($this->proxyInterfaceName !== null && $proxyClass->implementsInterface($this->proxyInterfaceName)) {
             $parentClass = $proxyClass->getParentClass();
 
             if ($parentClass === false) {

--- a/src/Mapping/AbstractClassMetadataFactory.php
+++ b/src/Mapping/AbstractClassMetadataFactory.php
@@ -25,7 +25,7 @@ use function substr;
 
 /**
  * The ClassMetadataFactory is used to create ClassMetadata objects that contain all the
- * metadata mapping informations of a class which describes how a class should be mapped
+ * metadata mapping information of a class which describes how a class should be mapped
  * to a relational database.
  *
  * This class was abstracted from the ORM ClassMetadataFactory.
@@ -91,6 +91,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
         return $metadata;
     }
 
+    /** @deprecated Since 5.0, native lazy objects don't use proxy classes and thus do not require a proxy class name resolver */
     public function setProxyClassNameResolver(ProxyClassNameResolver $resolver): void
     {
         $this->proxyClassNameResolver = $resolver;

--- a/src/Mapping/ProxyClassNameResolver.php
+++ b/src/Mapping/ProxyClassNameResolver.php
@@ -6,6 +6,7 @@ namespace Doctrine\Persistence\Mapping;
 
 use Doctrine\Persistence\Proxy;
 
+/** @deprecated Since 5.0: Native lazy objects don't use proxy classes anymore, this interface will be removed in Doctrine Persistence 6.0. */
 interface ProxyClassNameResolver
 {
     /**

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -7,6 +7,8 @@ namespace Doctrine\Persistence;
 /**
  * Interface for proxy classes.
  *
+ * @deprecated Since 5.0: Native lazy objects don't use proxy classes anymore, this interface will be removed in Doctrine Persistence 6.0.
+ *
  * @template T of object
  */
 interface Proxy


### PR DESCRIPTION
Native lazy objects don't need proxy classes. By deprecating interfaces and methods related to proxies, we can spot them more easily in integration and ensure we don't use them when native lazy objects are enabled.