### PR TITLE
Deprecate `ClassMetadataFactory::setMetadataFor()`

### DIFF
--- a/docs/en/reference/index.rst
+++ b/docs/en/reference/index.rst
@@ -149,9 +149,11 @@ your mapped PHP classes.
         public function getAllMetadata();
         public function getMetadataFor($className);
         public function hasMetadataFor($className);
-        public function setMetadataFor($className, $class);
+        public function setMetadataFor($className, $class); // Deprecated
         public function isTransient($className);
     }
+
+The method ``setMetadataFor()`` is deprecated and should not be used.
 
 Mapping Driver
 ==============

--- a/src/Mapping/AbstractClassMetadataFactory.php
+++ b/src/Mapping/AbstractClassMetadataFactory.php
@@ -232,7 +232,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     /**
      * Sets the metadata descriptor for a specific class.
      *
-     * NOTE: This is only useful in very special cases, like when generating proxy classes.
+     * @deprecated Since 4.2, use a custom ClassMetadataFactory implementation if you need to set metadata manually.
      *
      * @phpstan-param class-string $className
      * @phpstan-param CMTemplate $class

--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -41,6 +41,8 @@ interface ClassMetadataFactory
     /**
      * Sets the metadata descriptor for a specific class.
      *
+     * @deprecated Since 4.2, use a custom ClassMetadataFactory implementation if you need to set metadata manually.
+     *
      * @param class-string $className
      * @phpstan-param T $class
      */


### PR DESCRIPTION
This method is not used by Doctrine ORM or MongoDB ODM.

According to https://github.com/doctrine/orm/pull/12174, updating class metadata directly can lead to unexpected side effects.

Implementations can still have this method or other way to alter the class metadata, mainly for testing purposes, but this should not be exposed by the interface.