### PR TITLE
Require PHP 8.4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@12.1.0"
     with:
-      php-versions: '["8.1", "8.2", "8.3", "8.4", "8.5"]'
+      php-versions: '["8.4", "8.5"]'
       phpunit-options-lowest: "--do-not-fail-on-deprecation"
     secrets:
       CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,14 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
+# Upgrade to 5.0
+
+## BC Break: added type declarations to constants
+
+The code base now has constants with type declarations. If you extend types
+from the library and override the constants, you will need to add compatible
+type declarations.
+
 # Upgrade to 4.2
 
 ## Add `getFieldValue` and `setFieldValue` to `ClassMetadata` implementation

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         {"name": "Marco Pivetta", "email": "ocramius@gmail.com"}
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.4",
         "doctrine/deprecations": "^1",
         "doctrine/event-manager": "^1 || ^2",
         "psr/cache": "^1.0 || ^2.0 || ^3.0"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,7 +12,7 @@
     <!-- Ignore warnings and show progress of the run -->
     <arg value="nps"/>
 
-    <config name="php_version" value="80100"/>
+    <config name="php_version" value="80400"/>
 
     <file>src</file>
     <file>tests</file>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,7 @@ includes:
 
 parameters:
     level: 7
-    phpVersion: 80100
+    phpVersion: 80400
 
     paths:
         - src

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -35,7 +35,7 @@ interface ClassMetadata
     /**
      * Gets the ReflectionClass instance for this mapped class.
      *
-     * @return ReflectionClass<T>
+     * @return ReflectionClass<covariant T>
      */
     public function getReflectionClass(): ReflectionClass;
 

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -14,12 +14,12 @@ interface Proxy
     /**
      * Marker for Proxy class names.
      */
-    public const MARKER = '__CG__';
+    public const string MARKER = '__CG__';
 
     /**
      * Length of the proxy marker.
      */
-    public const MARKER_LENGTH = 6;
+    public const int MARKER_LENGTH = 6;
 
     /**
      * Initializes this proxy if its not yet initialized.

--- a/tests/RuntimeReflectionPropertyTest.php
+++ b/tests/RuntimeReflectionPropertyTest.php
@@ -54,6 +54,7 @@ class RuntimeReflectionPropertyTest extends TestCase
         $reflProperty = new RuntimeReflectionProperty($proxyClass, 'checkedProperty');
 
         self::assertSame('testValue', $reflProperty->getValue($mockProxy));
+        /** @phpstan-ignore unset.possiblyHookedProperty */
         unset($mockProxy->checkedProperty);
         self::assertNull($reflProperty->getValue($mockProxy));
     }


### PR DESCRIPTION
This is consistent with other Doctrine projects. Note that I had to add a "covariant" keyword on the template definition of `getReflectionClass()` return type. That's because since PHP 8.4, `ReflectionClass` is considered invariant because of lazy objects. Lazy objects introduce new methods to `ReflectionClass` where the template appears in parameter position, for instance that is the case for `isUninitializedLazyObject()`. I do not understand why this wasn't an issue with
`ReflectionClass::isInstance()`, which was introduced way earlier than that though.

The solution I picked is to use "call-site variance", effectively saying that this is OK in this instance (but it might not be, I'm not sure).

The alternative to adding this keyword would be to drop generic information entirely.

See https://github.com/phpstan/phpstan/issues/12459 for more details.