### PR TITLE
Support ClassLocator in StaticPHPDriver

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -61,6 +61,17 @@ return function (ClassMetadata $metadata): void {
 };
 ```
 
+## New methods in `StaticPHPDriver`
+
+The `StaticPHPDriver` get new method to configure the scanned directories:
+- `addExcludePaths(array $paths): void`
+- `getExcludePaths(): array`
+- `setFileExtension(string $fileExtension): void`
+- `getFileExtension(): string`
+
+Using the a `ClassLocator` implementation is recommended instead of relying
+on directory scanning.
+
 ## Do not pass any proxy interface to `AbstractManagerRegistry` when using native proxies
 
 With PHP 8.4 native lazy objects, you don't need to pass any proxy interface to

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -61,15 +61,16 @@ return function (ClassMetadata $metadata): void {
 };
 ```
 
-## New methods in `StaticPHPDriver`
+## `StaticPHPDriver` now accepts a `ClassLocator`
 
-The `StaticPHPDriver` get new method to configure the scanned directories:
-- `addExcludePaths(array $paths): void`
-- `getExcludePaths(): array`
-- `setFileExtension(string $fileExtension): void`
-- `getFileExtension(): string`
+The constructor of `StaticPHPDriver` now accepts a `ClassLocator` instance
+in addition to a path or array of paths:
 
-Using the a `ClassLocator` implementation is recommended instead of relying
+```php
+$driver = new StaticPHPDriver(new ClassNames([MyEntity::class, AnotherEntity::class]));
+```
+
+Using a `ClassLocator` implementation is recommended instead of relying
 on directory scanning.
 
 ## Do not pass any proxy interface to `AbstractManagerRegistry` when using native proxies

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,18 +31,6 @@ parameters:
 			path: tests/Mapping/ClassMetadataFactoryTest.php
 
 		-
-			message: '#^Parameter \#1 \$directories of static method Doctrine\\Persistence\\Mapping\\Driver\\FileClassLocator\:\:createFromDirectories\(\) expects list\<string\>, non\-empty\-array\<int, string\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/Mapping/ColocatedMappingDriverTest.php
-
-		-
-			message: '#^Parameter \#2 \$excludedDirectories of static method Doctrine\\Persistence\\Mapping\\Driver\\FileClassLocator\:\:createFromDirectories\(\) expects list\<string\>, array\<int, string\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/Mapping/ColocatedMappingDriverTest.php
-
-		-
 			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertSame\(\) with array\{''Doctrine\\\\Tests…'', ''Doctrine\\\\Tests\\\\ORM…'', ''Doctrine\\\\Tests\\\\ORM…''\} and list\<class\-string\> will always evaluate to false\.$#'
 			identifier: staticMethod.impossibleType
 			count: 1

--- a/src/Mapping/Driver/ColocatedMappingDriver.php
+++ b/src/Mapping/Driver/ColocatedMappingDriver.php
@@ -50,7 +50,7 @@ trait ColocatedMappingDriver
      */
     public function addPaths(array $paths): void
     {
-        $this->paths = array_unique(array_merge($this->paths, $paths));
+        $this->paths = array_unique([...$this->paths, ...$paths]);
     }
 
     /**

--- a/src/Mapping/Driver/FileClassLocator.php
+++ b/src/Mapping/Driver/FileClassLocator.php
@@ -81,9 +81,9 @@ final class FileClassLocator implements ClassLocator
     /**
      * Creates a FileClassLocator from an array of directories.
      *
-     * @param list<string> $directories
-     * @param list<string> $excludedDirectories Directories to exclude from the search.
-     * @param string       $fileExtension       The file extension to look for (default is '.php').
+     * @param string[] $directories
+     * @param string[] $excludedDirectories Directories to exclude from the search.
+     * @param string   $fileExtension       The file extension to look for (default is '.php').
      *
      * @throws MappingException if any of the directories are not valid.
      */

--- a/src/Mapping/Driver/StaticPHPDriver.php
+++ b/src/Mapping/Driver/StaticPHPDriver.php
@@ -16,7 +16,14 @@ use function method_exists;
  */
 class StaticPHPDriver implements MappingDriver
 {
-    use ColocatedMappingDriver;
+    use ColocatedMappingDriver {
+        addPaths as private;
+        getPaths as private;
+        addExcludePaths as private;
+        getExcludePaths as private;
+        getFileExtension as private;
+        setFileExtension as private;
+    }
 
     /** @param array<int, string>|string|ClassLocator $paths */
     public function __construct(array|string|ClassLocator $paths)

--- a/src/Mapping/Driver/StaticPHPDriver.php
+++ b/src/Mapping/Driver/StaticPHPDriver.php
@@ -5,17 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\Persistence\Mapping\Driver;
 
 use Doctrine\Persistence\Mapping\ClassMetadata;
-use Doctrine\Persistence\Mapping\MappingException;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-use ReflectionClass;
 
-use function array_unique;
-use function get_declared_classes;
-use function in_array;
-use function is_dir;
 use function method_exists;
-use function realpath;
 
 /**
  * The StaticPHPDriver calls a static loadMetadata() method on your entity
@@ -25,95 +16,21 @@ use function realpath;
  */
 class StaticPHPDriver implements MappingDriver
 {
-    /**
-     * Paths of entity directories.
-     *
-     * @var array<int, string>
-     */
-    private array $paths = [];
+    use ColocatedMappingDriver;
 
-    /**
-     * Map of all class names.
-     *
-     * @var array<int, string>
-     * @phpstan-var list<class-string>
-     */
-    private array|null $classNames = null;
-
-    /** @param array<int, string>|string $paths */
-    public function __construct(array|string $paths)
+    /** @param array<int, string>|string|ClassLocator $paths */
+    public function __construct(array|string|ClassLocator $paths)
     {
-        $this->addPaths((array) $paths);
-    }
-
-    /** @param array<int, string> $paths */
-    public function addPaths(array $paths): void
-    {
-        $this->paths = array_unique([...$this->paths, ...$paths]);
+        if ($paths instanceof ClassLocator) {
+            $this->classLocator = $paths;
+        } else {
+            $this->addPaths((array) $paths);
+        }
     }
 
     public function loadMetadataForClass(string $className, ClassMetadata $metadata): void
     {
         $className::loadMetadata($metadata);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @todo Same code exists in ColocatedMappingDriver, should we re-use it
-     * somehow or not worry about it?
-     */
-    public function getAllClassNames(): array
-    {
-        if ($this->classNames !== null) {
-            return $this->classNames;
-        }
-
-        if ($this->paths === []) {
-            throw MappingException::pathRequiredForDriver(static::class);
-        }
-
-        $classes       = [];
-        $includedFiles = [];
-
-        foreach ($this->paths as $path) {
-            if (! is_dir($path)) {
-                throw MappingException::fileMappingDriversRequireConfiguredDirectoryPath($path);
-            }
-
-            $iterator = new RecursiveIteratorIterator(
-                new RecursiveDirectoryIterator($path),
-                RecursiveIteratorIterator::LEAVES_ONLY,
-            );
-
-            foreach ($iterator as $file) {
-                if ($file->getBasename('.php') === $file->getBasename()) {
-                    continue;
-                }
-
-                $sourceFile = realpath($file->getPathName());
-                require_once $sourceFile;
-                $includedFiles[] = $sourceFile;
-            }
-        }
-
-        $declared = get_declared_classes();
-
-        foreach ($declared as $className) {
-            $rc = new ReflectionClass($className);
-
-            $sourceFile = $rc->getFileName();
-
-            if (! in_array($sourceFile, $includedFiles, true) || $this->isTransient($className)) {
-                continue;
-            }
-
-            $classes[] = $className;
-        }
-
-        $this->classNames = $classes;
-
-        return $classes;
     }
 
     public function isTransient(string $className): bool

--- a/tests/Mapping/ColocatedMappingDriverTest.php
+++ b/tests/Mapping/ColocatedMappingDriverTest.php
@@ -130,7 +130,7 @@ final class MyDriver implements MappingDriver
         if ($paths instanceof ClassLocator) {
             $this->classLocator = $paths;
         } else {
-            $this->paths = $paths;
+            $this->addPaths($paths);
         }
     }
 

--- a/tests/Mapping/StaticPHPDriverTest.php
+++ b/tests/Mapping/StaticPHPDriverTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\Persistence\Mapping;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\ClassNames;
 use Doctrine\Persistence\Mapping\Driver\StaticPHPDriver;
+use Doctrine\Tests\Persistence\Mapping\_files\colocated\Entity;
 use PHPUnit\Framework\TestCase;
 
 class StaticPHPDriverTest extends TestCase
@@ -16,32 +17,23 @@ class StaticPHPDriverTest extends TestCase
         $metadata = $this->createMock(ClassMetadata::class);
         $metadata->expects(self::once())->method('getFieldNames');
 
-        $driver = new StaticPHPDriver([__DIR__]);
-        $driver->loadMetadataForClass(TestEntity::class, $metadata);
+        $driver = new StaticPHPDriver([]);
+        $driver->loadMetadataForClass(Entity::class, $metadata);
     }
 
     public function testGetAllClassNames(): void
     {
-        $driver     = new StaticPHPDriver([__DIR__]);
+        $driver     = new StaticPHPDriver([__DIR__ . '/_files/colocated/']);
         $classNames = $driver->getAllClassNames();
 
-        self::assertContains(TestEntity::class, $classNames);
+        self::assertContains(Entity::class, $classNames);
     }
 
     public function testGetAllClassesNamesWithClassLocator(): void
     {
-        $driver     = new StaticPHPDriver(new ClassNames([TestEntity::class]));
+        $driver     = new StaticPHPDriver(new ClassNames([Entity::class]));
         $classNames = $driver->getAllClassNames();
 
-        self::assertSame([TestEntity::class], $classNames);
-    }
-}
-
-class TestEntity
-{
-    /** @phpstan-param ClassMetadata<object> $metadata */
-    public static function loadMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->getFieldNames();
+        self::assertSame([Entity::class], $classNames);
     }
 }

--- a/tests/Mapping/StaticPHPDriverTest.php
+++ b/tests/Mapping/StaticPHPDriverTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Persistence\Mapping;
 
 use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\Driver\ClassNames;
 use Doctrine\Persistence\Mapping\Driver\StaticPHPDriver;
 use PHPUnit\Framework\TestCase;
 
@@ -25,6 +26,14 @@ class StaticPHPDriverTest extends TestCase
         $classNames = $driver->getAllClassNames();
 
         self::assertContains(TestEntity::class, $classNames);
+    }
+
+    public function testGetAllClassesNamesWithClassLocator(): void
+    {
+        $driver     = new StaticPHPDriver(new ClassNames([TestEntity::class]));
+        $classNames = $driver->getAllClassNames();
+
+        self::assertSame([TestEntity::class], $classNames);
     }
 }
 

--- a/tests/Mapping/StaticPHPDriverTest.php
+++ b/tests/Mapping/StaticPHPDriverTest.php
@@ -9,9 +9,30 @@ use Doctrine\Persistence\Mapping\Driver\ClassNames;
 use Doctrine\Persistence\Mapping\Driver\StaticPHPDriver;
 use Doctrine\Tests\Persistence\Mapping\_files\colocated\Entity;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+use function array_map;
+use function sort;
 
 class StaticPHPDriverTest extends TestCase
 {
+    public function testPublicApi(): void
+    {
+        $publicMethods = array_map(
+            static fn (ReflectionMethod $m): string => $m->getName(),
+            (new ReflectionClass(StaticPHPDriver::class))->getMethods(ReflectionMethod::IS_PUBLIC),
+        );
+        sort($publicMethods);
+
+        self::assertSame([
+            '__construct',
+            'getAllClassNames',
+            'isTransient',
+            'loadMetadataForClass',
+        ], $publicMethods);
+    }
+
     public function testLoadMetadata(): void
     {
         $metadata = $this->createMock(ClassMetadata::class);

--- a/tests/Mapping/_files/colocated/Entity.php
+++ b/tests/Mapping/_files/colocated/Entity.php
@@ -4,10 +4,17 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Persistence\Mapping\_files\colocated;
 
+use Doctrine\Persistence\Mapping\ClassMetadata;
+
 /**
  * The driver should include this file and return its class name
  * from {@see \Doctrine\Persistence\Mapping\Driver\ColocatedMappingDriver::getAllClassNames()} method.
  */
 class Entity
 {
+    /** @phpstan-param ClassMetadata<object> $metadata */
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->getFieldNames();
+    }
 }


### PR DESCRIPTION
The `ClassLocator` abstraction added in https://github.com/doctrine/persistence/pull/433 should be used for the `StaticPHPDriver`.

By using the `ColocatedMappingDriver` trait, we remove code duplication.

- fix `StaticPHPDriverTest::testGetAllClassNames` by only scanning `/_files/colocated/`. Otherwise it loads the `Doctrine.Tests.Persistence.Mapping.PHPTestEntityAssert.php` file that expects the variable `$metadata` to be defined. This test passes when all the test suite is run, but not individually.

- Relax PHPStan type for list of directories in `FileClassLocator::createFromDirectories()` as we don't care about the array key.