### PR TITLE
Require files loaded by the `PHPDriver` to return a `Closure`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -21,6 +21,30 @@ The code base now has constants with type declarations. If you extend types
 from the library and override the constants, you will need to add compatible
 type declarations.
 
+## BC Break: Require files loaded by the `PHPDriver` to return a `Closure`
+
+If you use the `PHPDriver` for configuring metadata in PHP files, you must wrap 
+the code in a closure that is returned by the configuration file.
+
+Before:
+
+```php
+<?php // mappings/App.Entity.User.php
+
+$metadata->name = \App\Entity\User::class;
+```
+
+After:
+
+```php
+<?php // mappings/App.Entity.User.php
+
+use Doctrine\Persistence\Mapping\ClassMetadata;
+return function (ClassMetadata $metadata): void {
+    $metadata->name = \App\Entity\User::class;
+};
+```
+
 # Upgrade to 4.2
 
 ## Add `getFieldValue` and `setFieldValue` to `ClassMetadata` implementation

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     ],
     "require": {
         "php": "^8.4",
-        "doctrine/deprecations": "^1",
         "doctrine/event-manager": "^1 || ^2",
         "psr/cache": "^1.0 || ^2.0 || ^3.0"
     },

--- a/src/Mapping/Driver/PHPDriver.php
+++ b/src/Mapping/Driver/PHPDriver.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\Persistence\Mapping\Driver;
 
 use Closure;
-use CompileError;
-use Doctrine\Deprecations\Deprecation;
 use Doctrine\Persistence\Mapping\ClassMetadata;
-use Error;
+use Doctrine\Persistence\Mapping\MappingException;
 
 /**
  * The PHPDriver includes php files which just populate ClassMetadataInfo
@@ -39,19 +37,9 @@ class PHPDriver extends FileDriver
      */
     protected function loadMappingFile(string $file): array
     {
-        try {
-            $callback = Closure::bind(static function (string $file): mixed {
-                $metadata = null;
-
-                return include $file;
-            }, null, null)($file);
-        } catch (CompileError $e) {
-            throw $e;
-        } catch (Error) {
-            // Calling any method on $metadata=null will raise an Error
-            // Falling back to legacy behavior of expecting $metadata to be populated
-            $callback = null;
-        }
+        $callback = Closure::bind(static function (string $file): mixed {
+            return include $file;
+        }, null, null)($file);
 
         if ($callback instanceof Closure) {
             $callback($this->metadata);
@@ -59,16 +47,6 @@ class PHPDriver extends FileDriver
             return [$this->metadata->getName() => $this->metadata];
         }
 
-        Deprecation::trigger(
-            'doctrine/persistence',
-            'https://github.com/doctrine/persistence/pull/450',
-            'Not returning a Closure from a PHP mapping file is deprecated',
-        );
-
-        unset($callback);
-        $metadata = $this->metadata;
-        include $file;
-
-        return [$metadata->getName() => $metadata];
+        throw MappingException::phpFileMustReturnAClosure($file);
     }
 }

--- a/src/Mapping/MappingException.php
+++ b/src/Mapping/MappingException.php
@@ -77,4 +77,12 @@ class MappingException extends Exception
     {
         return new self(sprintf('Class "%s" is anonymous', $className));
     }
+
+    public static function phpFileMustReturnAClosure(string $fileName): self
+    {
+        return new self(sprintf(
+            'The PHP mapping file "%s" must return a Closure that receives the ClassMetadata instance as argument.',
+            $fileName,
+        ));
+    }
 }

--- a/tests/Mapping/PHPDriverTest.php
+++ b/tests/Mapping/PHPDriverTest.php
@@ -4,30 +4,23 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Persistence\Mapping;
 
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\PHPDriver;
+use Doctrine\Persistence\Mapping\MappingException;
 use Error;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
-use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class PHPDriverTest extends TestCase
 {
-    use VerifyDeprecations;
-
-    /** @phpstan-param class-string $className */
-    #[IgnoreDeprecations]
-    #[TestWith([PHPTestEntity::class])]
-    #[TestWith([PHPTestEntityAssert::class])]
-    public function testLoadMetadata(string $className): void
+    public function testLoadMetadata(): void
     {
-        $metadata = $this->createMock(ClassMetadata::class);
-        $metadata->expects(self::once())->method('getFieldNames');
-        $driver = new PHPDriver([__DIR__ . '/_files']);
+        $metadata = self::createStub(ClassMetadata::class);
+        $driver   = new PHPDriver([__DIR__ . '/_files']);
 
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/persistence/pull/450');
-        $driver->loadMetadataForClass($className, $metadata);
+        self::expectException(MappingException::class);
+        self::expectExceptionMessage('The PHP mapping file "' . __DIR__ . '/_files/Doctrine.Tests.Persistence.Mapping.PHPTestEntity.php" must return a Closure that receives the ClassMetadata instance as argument.');
+
+        $driver->loadMetadataForClass(PHPTestEntity::class, $metadata);
     }
 
     public function testLoadMetadataWithClosure(): void
@@ -63,10 +56,6 @@ class PHPDriverTest extends TestCase
 }
 
 class PHPTestEntity
-{
-}
-
-class PHPTestEntityAssert
 {
 }
 

--- a/tests/Mapping/_files/Doctrine.Tests.Persistence.Mapping.PHPTestEntity.php
+++ b/tests/Mapping/_files/Doctrine.Tests.Persistence.Mapping.PHPTestEntity.php
@@ -1,5 +1,3 @@
 <?php
 
 declare(strict_types=1);
-
-$metadata->getFieldNames();

--- a/tests/Mapping/_files/Doctrine.Tests.Persistence.Mapping.PHPTestEntityAssert.php
+++ b/tests/Mapping/_files/Doctrine.Tests.Persistence.Mapping.PHPTestEntityAssert.php
@@ -1,8 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-use Doctrine\Persistence\Mapping\ClassMetadata;
-
-assert($metadata instanceof ClassMetadata);
-$metadata->getFieldNames();


### PR DESCRIPTION
Follow-up https://github.com/doctrine/persistence/pull/450

If you use the `PHPDriver` for configuring metadata in PHP files, you must wrap 
the code in a closure that is returned by the configuration file.

```diff
<?php // mappings/App.Entity.User.php

use Doctrine\Persistence\Mapping\ClassMetadata;

- assert($metadata instanceof ClassMetadata);
- $metadata->name = \App\Entity\User::class;
+ return function (ClassMetadata $metadata): void {
+     $metadata->name = \App\Entity\User::class;
+ };
```