### PR TITLE
Fix PHPUnit warning for mocks without expectation, use stubs instead

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,7 +25,7 @@ parameters:
 			path: src/Reflection/EnumReflectionProperty.php
 
 		-
-			message: '#^PHPDoc tag @var with type Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\> is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
+			message: '#^PHPDoc tag @var with type Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\> is not subtype of native type PHPUnit\\Framework\\MockObject\\Stub\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: tests/Mapping/ClassMetadataFactoryTest.php

--- a/tests/Event/PreUpdateEventArgsTest.php
+++ b/tests/Event/PreUpdateEventArgsTest.php
@@ -70,7 +70,7 @@ class PreUpdateEventArgsTest extends TestCase
     {
         $entity = new TestObject();
 
-        $objectManager = $this->createMock(ObjectManager::class);
+        $objectManager = self::createStub(ObjectManager::class);
 
         $entityChangeset = [
             'name' => ['old', 'new'],

--- a/tests/ManagerRegistryTest.php
+++ b/tests/ManagerRegistryTest.php
@@ -74,7 +74,7 @@ class ManagerRegistryTest extends TestCase
 
     public function testGetRepository(): void
     {
-        $repository = $this->createMock(ObjectRepository::class);
+        $repository = self::createStub(ObjectRepository::class);
 
         $defaultManager = $this->mr->getManager();
         assert($defaultManager instanceof MockObject);
@@ -99,7 +99,7 @@ class ManagerRegistryTest extends TestCase
             $this->getManagerFactory(),
         );
 
-        $repository = $this->createMock(ObjectRepository::class);
+        $repository = self::createStub(ObjectRepository::class);
 
         $defaultManager = $this->mr->getManager();
         assert($defaultManager instanceof MockObject);
@@ -130,7 +130,7 @@ class ManagerRegistryTest extends TestCase
             $this->getManagerFactory(),
         );
 
-        $repository = $this->createMock(ObjectRepository::class);
+        $repository = self::createStub(ObjectRepository::class);
 
         $defaultManager = $this->mr->getManager();
         assert($defaultManager instanceof MockObject);
@@ -153,9 +153,10 @@ class ManagerRegistryTest extends TestCase
     {
         return function (string $name) {
             $mock = $this->createMock(ObjectManager::class);
+            $mock->expects($this->never())->method('clear');
 
-            $driver   = $this->createMock(MappingDriver::class);
-            $metadata = $this->createMock(ClassMetadata::class);
+            $driver   = self::createStub(MappingDriver::class);
+            $metadata = self::createStub(ClassMetadata::class);
 
             $metadata
                 ->method('getName')

--- a/tests/Mapping/AbstractClassMetadataFactoryTest.php
+++ b/tests/Mapping/AbstractClassMetadataFactoryTest.php
@@ -28,7 +28,7 @@ final class AbstractClassMetadataFactoryTest extends TestCase
         $cmf    = $this->createTestFactory($driver);
 
         $metadataCallCount                     = 0;
-        $cmf->newClassMetadataInstanceCallback = function ($className) use (&$metadataCallCount) {
+        $cmf->newClassMetadataInstanceCallback = static function ($className) use (&$metadataCallCount) {
             $metadataCallCount++;
             if ($metadataCallCount === 1) {
                 self::assertEquals(SomeGrandParentEntity::class, $className);
@@ -36,7 +36,7 @@ final class AbstractClassMetadataFactoryTest extends TestCase
                 self::assertEquals(SomeEntity::class, $className);
             }
 
-            return $this->createMock(ClassMetadata::class);
+            return self::createStub(ClassMetadata::class);
         };
 
         $driverCallCount = 0;
@@ -70,7 +70,7 @@ final class AbstractClassMetadataFactoryTest extends TestCase
 
     public function testAnonymousClassIsNotMistakenForShortAlias(): void
     {
-        $driver = $this->createMock(MappingDriver::class);
+        $driver = self::createStub(MappingDriver::class);
         $driver->method('isTransient')->willReturn(false);
         $cmf = $this->createTestFactory($driver);
 
@@ -96,7 +96,7 @@ final class AbstractClassMetadataFactoryTest extends TestCase
 
     public function testItGetsTheSameMetadataForBackslashedClassName(): void
     {
-        $driver = $this->createMock(MappingDriver::class);
+        $driver = self::createStub(MappingDriver::class);
         $cmf    = $this->createTestFactory($driver);
 
         $metadata                              = self::createStub(ClassMetadata::class);

--- a/tests/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Mapping/ClassMetadataFactoryTest.php
@@ -26,10 +26,10 @@ class ClassMetadataFactoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $driver = $this->createMock(MappingDriver::class);
+        $driver = self::createStub(MappingDriver::class);
 
         /** @phpstan-var ClassMetadata<object> */
-        $metadata  = $this->createMock(ClassMetadata::class);
+        $metadata  = self::createStub(ClassMetadata::class);
         $this->cmf = new TestClassMetadataFactory($driver, $metadata);
     }
 
@@ -65,7 +65,7 @@ class ClassMetadataFactoryTest extends TestCase
 
     public function testGetCachedMetadata(): void
     {
-        $metadata = $this->createMock(ClassMetadata::class);
+        $metadata = self::createStub(ClassMetadata::class);
         $cache    = new ArrayAdapter();
         $item     = $cache->getItem($this->cmf->getCacheKey(ChildEntity::class));
         $item->set($metadata);
@@ -90,7 +90,7 @@ class ClassMetadataFactoryTest extends TestCase
 
     public function testWillFallbackOnNotLoadedMetadata(): void
     {
-        $classMetadata = $this->createMock(ClassMetadata::class);
+        $classMetadata = self::createStub(ClassMetadata::class);
 
         $this->cmf->fallbackCallback = static fn () => $classMetadata;
 

--- a/tests/Mapping/DriverChainTest.php
+++ b/tests/Mapping/DriverChainTest.php
@@ -22,7 +22,7 @@ class DriverChainTest extends TestCase
     public function testDelegateToMatchingNamespaceDriver(string $namespace1, string $namespace2): void
     {
         $className     = DriverChainEntity::class;
-        $classMetadata = $this->createMock(ClassMetadata::class);
+        $classMetadata = self::createStub(ClassMetadata::class);
 
         $chain = new MappingDriverChain();
 
@@ -52,7 +52,7 @@ class DriverChainTest extends TestCase
     public function testLoadMetadataShouldThrowMappingExceptionWhenNoDelegatorWasFound(): void
     {
         $className     = DriverChainEntity::class;
-        $classMetadata = $this->createMock(ClassMetadata::class);
+        $classMetadata = self::createStub(ClassMetadata::class);
 
         $chain = new MappingDriverChain();
 
@@ -87,7 +87,7 @@ class DriverChainTest extends TestCase
     #[Group('DDC-706')]
     public function testIsTransient(): void
     {
-        $driver1 = $this->createMock(MappingDriver::class);
+        $driver1 = self::createStub(MappingDriver::class);
         $chain   = new MappingDriverChain();
         $chain->addDriver($driver1, 'Doctrine\Tests\Models\CMS');
 

--- a/tests/Mapping/FileDriverTest.php
+++ b/tests/Mapping/FileDriverTest.php
@@ -12,6 +12,7 @@ use Doctrine\Tests\Persistence\Mapping\Fixtures\GlobalClass;
 use Doctrine\Tests\Persistence\Mapping\Fixtures\NotLoadedClass;
 use Doctrine\Tests\Persistence\Mapping\Fixtures\TestClassMetadata;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -43,7 +44,7 @@ class FileDriverTest extends TestCase
 
     public function testGetElementFromFile(): void
     {
-        $locator = $this->newLocator();
+        $locator = $this->newLocator(true);
         $locator->expects(self::once())
                 ->method('findMappingFile')
                 ->with(self::equalTo(stdClass::class))
@@ -56,7 +57,7 @@ class FileDriverTest extends TestCase
 
     public function testGetElementUpdatesClassCache(): void
     {
-        $locator = $this->newLocator();
+        $locator = $this->newLocator(true);
 
         // findMappingFile should only be called once
         $locator->expects(self::once())
@@ -118,7 +119,7 @@ class FileDriverTest extends TestCase
 
     public function testGetAllClassNamesBothSourcesNoDupes(): void
     {
-        $locator = $this->newLocator();
+        $locator = $this->newLocator(true);
         $locator->expects(self::once())
                 ->method('getAllClassNames')
                 ->with(self::equalTo('global'))
@@ -138,7 +139,7 @@ class FileDriverTest extends TestCase
 
     public function testIsNotTransient(): void
     {
-        $locator = $this->newLocator();
+        $locator = $this->newLocator(true);
         $locator->expects(self::once())
                 ->method('fileExists')
                 ->with(self::equalTo(stdClass::class))
@@ -154,7 +155,7 @@ class FileDriverTest extends TestCase
 
     public function testIsTransient(): void
     {
-        $locator = $this->newLocator();
+        $locator = $this->newLocator(true);
         $locator->expects(self::once())
                 ->method('fileExists')
                 ->with(self::equalTo(NotLoadedClass::class))
@@ -172,10 +173,10 @@ class FileDriverTest extends TestCase
         self::assertFalse($driver->isTransient(stdClass::class));
     }
 
-    /** @return FileLocator&MockObject */
-    private function newLocator(): MockObject
+    /** @return ($mock is true ? (FileLocator&MockObject) : (FileLocator&Stub)) */
+    private function newLocator(bool $mock = false): FileLocator
     {
-        $locator = $this->createMock(FileLocator::class);
+        $locator = $mock ? $this->createMock(FileLocator::class) : self::createStub(FileLocator::class);
         $locator->method('getFileExtension')->willReturn('.yml');
         $locator->method('getPaths')->willReturn([__DIR__ . '/_files']);
 
@@ -187,9 +188,9 @@ class FileDriverTest extends TestCase
     {
         $driver = new TestFileDriver($locator, $fileExtension);
 
-        $driver->stdClass   = $this->createMock(ClassMetadata::class);
-        $driver->stdGlobal  = $this->createMock(ClassMetadata::class);
-        $driver->stdGlobal2 = $this->createMock(ClassMetadata::class);
+        $driver->stdClass   = self::createStub(ClassMetadata::class);
+        $driver->stdGlobal  = self::createStub(ClassMetadata::class);
+        $driver->stdGlobal2 = self::createStub(ClassMetadata::class);
 
         return $driver;
     }

--- a/tests/ObjectManagerDecoratorTest.php
+++ b/tests/ObjectManagerDecoratorTest.php
@@ -98,7 +98,7 @@ class ObjectManagerDecoratorTest extends TestCase
 
     public function testGetRepository(): void
     {
-        $repository = $this->createMock(ObjectRepository::class);
+        $repository = self::createStub(ObjectRepository::class);
 
         $this->wrapped->expects(self::once())
             ->method('getRepository')
@@ -110,7 +110,7 @@ class ObjectManagerDecoratorTest extends TestCase
 
     public function testGetClassMetadata(): void
     {
-        $classMetadata = $this->createMock(ClassMetadata::class);
+        $classMetadata = self::createStub(ClassMetadata::class);
 
         $this->wrapped->expects(self::once())
             ->method('getClassMetadata')
@@ -122,7 +122,7 @@ class ObjectManagerDecoratorTest extends TestCase
 
     public function testGetClassMetadataFactory(): void
     {
-        $classMetadataFactory = $this->createMock(ClassMetadataFactory::class);
+        $classMetadataFactory = self::createStub(ClassMetadataFactory::class);
 
         $this->wrapped->expects(self::once())
             ->method('getMetadataFactory')


### PR DESCRIPTION
Fix the new notice of PHPUnit [12.5.0](https://github.com/sebastianbergmann/phpunit/releases/tag/12.5.0). 

> A PHPUnit notice is now emitted for test methods that create a mock object but do not configure an expectation for it

Example of PHPUnit notice when running `./vendor/bin/phpunit --display-all-issues`:
```
1) Doctrine\Tests\Persistence\Mapping\AbstractClassMetadataFactoryTest::testItGetsTheSameMetadataForBackslashedClassName
No expectations were configured for the mock object for Doctrine\Persistence\Mapping\Driver\MappingDriver. You should refactor your test code and use a test stub instead.
```