### PR TITLE
Use Rector on tests

### DIFF
--- a/tests/Mapping/AbstractClassMetadataFactoryTest.php
+++ b/tests/Mapping/AbstractClassMetadataFactoryTest.php
@@ -134,8 +134,8 @@ class TestAbstractClassMetadataFactory extends AbstractClassMetadataFactory
 
     /** @param ClassMetadata<object>|null $defaultMetadata */
     public function __construct(
-        private MappingDriver|null $driver = null,
-        private ClassMetadata|null $defaultMetadata = null,
+        private readonly MappingDriver|null $driver = null,
+        private readonly ClassMetadata|null $defaultMetadata = null,
     ) {
     }
 

--- a/tests/Mapping/RuntimeReflectionServiceTest.php
+++ b/tests/Mapping/RuntimeReflectionServiceTest.php
@@ -21,9 +21,11 @@ class RuntimeReflectionServiceTest extends TestCase
 
     public mixed $unusedPublicProperty;
 
-    private string $typedNoDefaultProperty;
+    /** @phpstan-ignore property.uninitializedReadonly */
+    private readonly string $typedNoDefaultProperty;
     private string $typedDefaultProperty = '';
-    private string $nonTypedNoDefaultProperty; // phpcs:ignore SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty
+    /** @phpstan-ignore property.uninitializedReadonly */
+    private readonly string $nonTypedNoDefaultProperty; // phpcs:ignore SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty
     private string $nonTypedDefaultProperty = ''; // phpcs:ignore SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty
 
     public string $typedNoDefaultPublicProperty;

--- a/tests/Reflection/TypedNoDefaultReflectionPropertyTest.php
+++ b/tests/Reflection/TypedNoDefaultReflectionPropertyTest.php
@@ -72,7 +72,7 @@ class TypedFoo
 
 class TypedNullableFoo
 {
-    private string|null $value;
+    private string|null $value = null;
 
     public function setValue(mixed $value): void
     {

--- a/tests/RuntimeReflectionPropertyTest.php
+++ b/tests/RuntimeReflectionPropertyTest.php
@@ -39,8 +39,8 @@ class RuntimeReflectionPropertyTest extends TestCase
     }
 
     /** @param class-string<RuntimeReflectionPropertyTestProxyMock> $proxyClass */
-    #[TestWith(['Doctrine\\Tests\\Persistence\\RuntimeReflectionPropertyTestProxyMock'])]
-    #[TestWith(['\\Doctrine\\Tests\\Persistence\\RuntimeReflectionPropertyTestProxyMock'])]
+    #[TestWith([RuntimeReflectionPropertyTestProxyMock::class])]
+    #[TestWith([RuntimeReflectionPropertyTestProxyMock::class])]
     public function testGetValueOnProxyProperty(string $proxyClass): void
     {
         $getCheckMock = $this->createMock(DummyMock::class);


### PR DESCRIPTION
This is the configuration I used:

```php
<?php

declare(strict_types=1);

use Rector\Config\RectorConfig;

return RectorConfig::configure()
	->withPaths([
	__DIR__ . '/tests',
	])
	->withPhpSets();
```