### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -54,58 +54,13 @@
             "maintained": false
         },
         {
-            "name": "3.0",
-            "slug": "3.0",
-            "maintained": false
-        },
-        {
             "name": "2.5",
             "slug": "2.5",
             "maintained": false
         },
         {
-            "name": "2.4",
-            "slug": "2.4",
-            "maintained": false
-        },
-        {
-            "name": "2.3",
-            "slug": "2.3",
-            "maintained": false
-        },
-        {
-            "name": "2.2",
-            "slug": "2.2",
-            "maintained": false
-        },
-        {
-            "name": "2.1",
-            "slug": "2.1",
-            "maintained": false
-        },
-        {
-            "name": "2.0",
-            "slug": "2.0",
-            "maintained": false
-        },
-        {
             "name": "1.3",
             "slug": "1.3",
-            "maintained": false
-        },
-        {
-            "name": "1.2",
-            "slug": "1.2",
-            "maintained": false
-        },
-        {
-            "name": "1.1",
-            "slug": "1.1",
-            "maintained": false
-        },
-        {
-            "name": "1.0",
-            "slug": "1.0",
             "maintained": false
         }
     ]

--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -11,16 +11,21 @@
             "upcoming": true
         },
         {
-            "name": "4.2",
-            "branchName": "4.2.x",
-            "slug": "4.2",
+            "name": "4.3",
+            "branchName": "4.3.x",
+            "slug": "4.3",
             "upcoming": true
         },
         {
-            "name": "4.1",
-            "branchName": "4.1.x",
-            "slug": "4.1",
+            "name": "4.2",
+            "branchName": "4.2.x",
+            "slug": "4.2",
             "current": true
+        },
+        {
+            "name": "4.1",
+            "slug": "4.1",
+            "maintained": false
         },
         {
             "name": "4.0",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Doctrine Persistence
 
-[![GitHub Actions][GA 4.0 image]][GA 4.0]
-[![Code Coverage][Coverage 4.0 image]][CodeCov 4.0]
+[![GitHub Actions][GA 4.2 image]][GA 4.2]
+[![Code Coverage][Coverage 4.2 image]][CodeCov 4.2]
 
 The Doctrine Persistence project is a library that provides common abstractions for object mapper persistence.
 
@@ -11,7 +11,7 @@ The Doctrine Persistence project is a library that provides common abstractions 
 * [Documentation](https://www.doctrine-project.org/projects/doctrine-persistence/en/latest/index.html)
 * [Downloads](https://github.com/doctrine/persistence/releases)
 
-  [Coverage 4.0 image]: https://codecov.io/gh/doctrine/persistence/branch/4.0.x/graph/badge.svg
-  [CodeCov 4.0]: https://codecov.io/gh/doctrine/persistence/branch/4.0.x
-  [GA 4.0 image]: https://github.com/doctrine/persistence/actions/workflows/continuous-integration.yml/badge.svg?branch=4.0.x
-  [GA 4.0]: https://github.com/doctrine/persistence/actions/workflows/continuous-integration.yml?branch=4.0.x
+  [Coverage 4.2 image]: https://codecov.io/gh/doctrine/persistence/branch/4.2.x/graph/badge.svg
+  [CodeCov 4.2]: https://codecov.io/gh/doctrine/persistence/branch/4.2.x
+  [GA 4.2 image]: https://github.com/doctrine/persistence/actions/workflows/continuous-integration.yml/badge.svg?branch=4.2.x
+  [GA 4.2]: https://github.com/doctrine/persistence/actions/workflows/continuous-integration.yml?branch=4.2.x


### PR DESCRIPTION
4.2.0 has been released. As a consequence:

- 4.3.x is the next minor branch.
- 4.2.x is the current branch.
- 4.1.x is no longer maintained.