### PR TITLE
Convert ClassMetadata::getFieldValue/setFieldValue from @method to real interface methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,12 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC Break: `ClassMetadata::getFieldValue()` and `setFieldValue()` are now required
+
+The methods `getFieldValue()` and `setFieldValue()` are now required by the
+`Doctrine\Persistence\Mapping\ClassMetadata` interface. Implement them in your
+`ClassMetadata` implementations.
+
 ## BC Break: Final classes
 
 The following classes are now final and cannot be extended:

--- a/docs/en/reference/index.rst
+++ b/docs/en/reference/index.rst
@@ -125,6 +125,8 @@ ClassMetadata
         public function isSingleValuedAssociation($fieldName);
         public function isCollectionValuedAssociation($fieldName);
         public function getFieldNames();
+        public function getFieldValue(object $object, string $field): mixed;
+        public function setFieldValue(object $object, string $field, mixed $value): void;
         public function getIdentifierFieldNames();
         public function getAssociationNames();
         public function getTypeOfField($fieldName);

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\Persistence\Mapping;
 
+use InvalidArgumentException;
 use ReflectionClass;
 
 /**
  * Contract for a Doctrine persistence layer ClassMetadata class to implement.
  *
  * @template-covariant T of object
- * @method mixed getFieldValue(object $entity, string $field)
- * @method void  setFieldValue(object $entity, string $field, mixed $value)
  */
 interface ClassMetadata
 {
@@ -62,6 +61,20 @@ interface ClassMetadata
      * @return array<int, string>
      */
     public function getFieldNames(): array;
+
+    /**
+     * Gets the value of the given field of the given object.
+     *
+     * @throws InvalidArgumentException if the object is not supported, or the field is not mapped.
+     */
+    public function getFieldValue(object $object, string $field): mixed;
+
+    /**
+     * Sets the value of the given field of the given object to the given value.
+     *
+     * @throws InvalidArgumentException if the object is not supported, or the field is not mapped.
+     */
+    public function setFieldValue(object $object, string $field, mixed $value): void;
 
     /**
      * Returns an array of identifier field names numerically indexed.

--- a/tests/Mapping/Fixtures/TestClassMetadata.php
+++ b/tests/Mapping/Fixtures/TestClassMetadata.php
@@ -80,6 +80,18 @@ final class TestClassMetadata implements ClassMetadata
         return [];
     }
 
+    #[Override]
+    public function getFieldValue(object $object, string $field): mixed
+    {
+        throw new LogicException('Not implemented');
+    }
+
+    #[Override]
+    public function setFieldValue(object $object, string $field, mixed $value): void
+    {
+        throw new LogicException('Not implemented');
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
Closes #451

`@param T $entity` is used on both methods even though `T` is declared covariant. This is intentional( the methods only make sense for the mapped entity type) but it violates strict generic variance rules. PHPStan warnings are suppressed with `@phpstan-ignore generics.variance`.

Open question: should `@template-covariant T` be relaxed to `@template T` (invariant) to model this more accurately? That would be a breaking change for downstream type annotations.