### PR TITLE
fix: Add parent constructor call in EnumReflectionProperty

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,18 +19,6 @@ parameters:
 			path: src/ObjectManagerDecorator.php
 
 		-
-			message: '#^Doctrine\\Persistence\\Reflection\\EnumReflectionProperty\:\:__construct\(\) does not call parent constructor from ReflectionProperty\.$#'
-			identifier: constructor.missingParentCall
-			count: 1
-			path: src/Reflection/EnumReflectionProperty.php
-
-		-
-			message: '#^Method Doctrine\\Persistence\\Reflection\\EnumReflectionProperty\:\:getDeclaringClass\(\) return type with generic class ReflectionClass does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Reflection/EnumReflectionProperty.php
-
-		-
 			message: '#^Method Doctrine\\Persistence\\Reflection\\EnumReflectionProperty\:\:toEnum\(\) should return array\<BackedEnum\>\|BackedEnum but returns array\<BackedEnum\|int\|string\>\.$#'
 			identifier: return.type
 			count: 1

--- a/src/Reflection/EnumReflectionProperty.php
+++ b/src/Reflection/EnumReflectionProperty.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Persistence\Reflection;
 
 use BackedEnum;
-use ReflectionClass;
 use ReflectionProperty;
-use ReflectionType;
 use ReturnTypeWillChange;
 
 use function array_map;
@@ -28,31 +26,10 @@ class EnumReflectionProperty extends ReflectionProperty
     /** @param class-string<BackedEnum> $enumType */
     public function __construct(ReflectionProperty $originalReflectionProperty, string $enumType)
     {
+        parent::__construct($originalReflectionProperty->class, $originalReflectionProperty->name);
+
         $this->originalReflectionProperty = $originalReflectionProperty;
         $this->enumType                   = $enumType;
-    }
-
-    public function getDeclaringClass(): ReflectionClass
-    {
-        return $this->originalReflectionProperty->getDeclaringClass();
-    }
-
-    public function getName(): string
-    {
-        return $this->originalReflectionProperty->getName();
-    }
-
-    public function getType(): ?ReflectionType
-    {
-        return $this->originalReflectionProperty->getType();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getAttributes(?string $name = null, int $flags = 0): array
-    {
-        return $this->originalReflectionProperty->getAttributes($name, $flags);
     }
 
     /**
@@ -132,20 +109,5 @@ class EnumReflectionProperty extends ReflectionProperty
         }
 
         return $this->enumType::from($value);
-    }
-
-    public function getModifiers(): int
-    {
-        return $this->originalReflectionProperty->getModifiers();
-    }
-
-    public function getDocComment(): string|false
-    {
-        return $this->originalReflectionProperty->getDocComment();
-    }
-
-    public function isPrivate(): bool
-    {
-        return $this->originalReflectionProperty->isPrivate();
     }
 }

--- a/tests_php81/Reflection/EnumReflectionPropertyTest.php
+++ b/tests_php81/Reflection/EnumReflectionPropertyTest.php
@@ -131,6 +131,18 @@ class EnumReflectionPropertyTest extends TestCase
         $reflProperty = new EnumReflectionProperty(new ReflectionProperty(TypedEnumClass::class, 'suit'), Suit::class);
         self::assertFalse($reflProperty->isPrivate());
     }
+
+    public function testIsPublic(): void
+    {
+        $reflProperty = new EnumReflectionProperty(new ReflectionProperty(TypedEnumClass::class, 'suit'), Suit::class);
+        self::assertTrue($reflProperty->isPublic());
+    }
+
+    public function testHasDefaultValue(): void
+    {
+        $reflProperty = new EnumReflectionProperty(new ReflectionProperty(TypedEnumClass::class, 'suit'), Suit::class);
+        self::assertTrue($reflProperty->hasDefaultValue());
+    }
 }
 
 #[Attribute(Attribute::TARGET_PROPERTY)]


### PR DESCRIPTION
Hello, this PR is a backport of #422 to the 3.4.x branch.  
The original fix was merged into 4.0.x, this PR applies the same solution to the 3.4.x branch.

The issue this PR solves is explained in: https://github.com/doctrine/persistence/issues/423