### PR TITLE
Refactor EnumReflectionProperty to remove $originalReflectionProperty

### DIFF
--- a/src/Reflection/EnumReflectionProperty.php
+++ b/src/Reflection/EnumReflectionProperty.php
@@ -19,7 +19,7 @@ use function reset;
 class EnumReflectionProperty extends ReflectionProperty
 {
     /** @param class-string<BackedEnum> $enumType */
-    public function __construct(private readonly ReflectionProperty $originalReflectionProperty, private readonly string $enumType)
+    public function __construct(ReflectionProperty $originalReflectionProperty, private readonly string $enumType)
     {
         parent::__construct($originalReflectionProperty->class, $originalReflectionProperty->name);
     }
@@ -39,7 +39,7 @@ class EnumReflectionProperty extends ReflectionProperty
             return null;
         }
 
-        $enum = $this->originalReflectionProperty->getValue($object);
+        $enum = parent::getValue($object);
 
         if ($enum === null) {
             return null;
@@ -59,7 +59,7 @@ class EnumReflectionProperty extends ReflectionProperty
             $value = $this->toEnum($value);
         }
 
-        $this->originalReflectionProperty->setValue($object, $value);
+        parent::setValue($object, $value);
     }
 
     /**


### PR DESCRIPTION
Hello, in this PR I propose to remove `$originalReflectionProperty` property from `EnumReflectionProperty` class. This is a refactoring, so no new functionality has been removed or added.

The reasons are:

* This will eliminate redundant state. `EnumReflectionProperty` extends `ReflectionProperty` and initializes the parent with the same information. Keeping a second reference means the object stores the same conceptual state twice.
* Removing `$originalReflectionProperty` makes it clear that `EnumReflectionProperty` itself is the authoritative reflection object. Developers no longer need to wonder whether a method should be called on `$this`, `$this->originalReflectionProperty`, or whether the two can diverge.
