### PR TITLE
Stop maintaining 3.x

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -34,9 +34,8 @@
         },
         {
             "name": "3.4",
-            "branchName": "3.4.x",
             "slug": "3.4",
-            "maintained": true
+            "maintained": false
         },
         {
             "name": "3.3",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
       interval: "weekly"
     labels:
       - "CI"
-    target-branch: "3.4.x"
     groups:
       doctrine:
         patterns:


### PR DESCRIPTION
The downloads of 4.x have surpassed the downloads of 3.x.

<img width="820" height="386" alt="image" src="https://github.com/user-attachments/assets/10baf596-5c20-48ec-8007-32ae9833d56f" />
