### PR TITLE
Handle root-namespace classes in SymfonyFileLocator

### DIFF
--- a/src/Mapping/Driver/SymfonyFileLocator.php
+++ b/src/Mapping/Driver/SymfonyFileLocator.php
@@ -11,10 +11,8 @@ use RecursiveIteratorIterator;
 use RuntimeException;
 
 use function array_keys;
-use function assert;
 use function is_dir;
 use function is_file;
-use function is_int;
 use function realpath;
 use function sprintf;
 use function str_replace;
@@ -222,12 +220,12 @@ class SymfonyFileLocator implements FileLocator
             }
         }
 
-        $pos = strrpos($className, '\\');
-        assert(is_int($pos));
+        $pos            = strrpos($className, '\\');
+        $shortClassName = $pos === false ? $className : substr($className, $pos + 1);
 
         throw MappingException::mappingFileNotFound(
             $className,
-            substr($className, $pos + 1) . $this->fileExtension,
+            $shortClassName . $this->fileExtension,
         );
     }
 

--- a/src/Mapping/Driver/SymfonyFileLocator.php
+++ b/src/Mapping/Driver/SymfonyFileLocator.php
@@ -11,6 +11,7 @@ use RecursiveIteratorIterator;
 use RuntimeException;
 
 use function array_keys;
+use function basename;
 use function is_dir;
 use function is_file;
 use function realpath;
@@ -18,7 +19,6 @@ use function sprintf;
 use function str_replace;
 use function str_starts_with;
 use function strlen;
-use function strrpos;
 use function strtr;
 use function substr;
 
@@ -220,12 +220,9 @@ class SymfonyFileLocator implements FileLocator
             }
         }
 
-        $pos            = strrpos($className, '\\');
-        $shortClassName = $pos === false ? $className : substr($className, $pos + 1);
-
         throw MappingException::mappingFileNotFound(
             $className,
-            $shortClassName . $this->fileExtension,
+            basename(str_replace('\\', '/', $className)) . $this->fileExtension,
         );
     }
 

--- a/tests/Mapping/SymfonyFileLocatorTest.php
+++ b/tests/Mapping/SymfonyFileLocatorTest.php
@@ -188,6 +188,15 @@ class SymfonyFileLocatorTest extends TestCase
         $locator->findMappingFile('Foo\\stdClass2');
     }
 
+    public function testFindMappingFileNotFoundForClassInRootNamespace(): void
+    {
+        $locator = new SymfonyFileLocator([], '.yml');
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage("No mapping file found named 'DateTime.yml' for class 'DateTime'.");
+        $locator->findMappingFile('DateTime');
+    }
+
     public function testFindMappingFileLeastSpecificNamespaceFirst(): void
     {
         // Low -> High


### PR DESCRIPTION
Fixes #520.

When a mapping lookup fails for a class in the root namespace, `strrpos()` returns `false`. The assertion then fails when assertions are enabled; when they are disabled, the subsequent `substr()` starts at offset 1 and reports a filename such as `ateTime.yml`.

Use the complete class name when there is no namespace separator, while preserving the existing short-name behavior for namespaced classes. The regression test verifies that `DateTime` produces the expected `MappingException` and filename.

Validation:

- `vendor/bin/phpunit` — 146 tests, 306 assertions
- `vendor/bin/phpcs` — 72 files
- `vendor/bin/phpstan analyse --no-progress --memory-limit=512M` — no errors