### PR TITLE
Allow SortDirection enum in ObjectRepository::findBy()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,15 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC Break: `ObjectRepository::findBy()` `$orderBy` additionally accepts the `SortDirection` enum
+
+The `$orderBy` parameter of `findBy()` now also accepts the PHP 8.6 `SortDirection`
+enum, in addition to the `'asc'`, `'desc'`, `'ASC'` and `'DESC'` strings. The native
+signature is unchanged and strings remain accepted.
+
+Implementations of `ObjectRepository` must accept the enum and cannot declare a
+more restrictive type for `$orderBy`.
+
 ## BC Break: `ClassMetadata::getFieldValue()` and `setFieldValue()` are now required
 
 The methods `getFieldValue()` and `setFieldValue()` are now required by the

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "doctrine/coding-standard": "^14",
         "phpunit/phpunit": "^10.5.58 || ^12",
         "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0 || ^8.0",
-        "symfony/finder": "^4.4 || ^5.4 || ^6.0 || ^7.0 || ^8.0"
+        "symfony/finder": "^4.4 || ^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/polyfill-php86": "^1.41"
     },
     "autoload": {
         "psr-4": {

--- a/src/ObjectRepository.php
+++ b/src/ObjectRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Persistence;
 
+use SortDirection;
 use UnexpectedValueException;
 
 /**
@@ -38,9 +39,9 @@ interface ObjectRepository
      * an UnexpectedValueException if certain values of the sorting or limiting details are
      * not supported.
      *
-     * @param array<string, mixed>       $criteria
-     * @param array<string, string>|null $orderBy
-     * @phpstan-param array<string, 'asc'|'desc'|'ASC'|'DESC'>|null $orderBy
+     * @param array<string, mixed>                     $criteria
+     * @param array<string, string|SortDirection>|null $orderBy
+     * @phpstan-param array<string, 'asc'|'desc'|'ASC'|'DESC'|SortDirection>|null $orderBy
      *
      * @return array<int, object> The objects.
      * @phpstan-return list<T>


### PR DESCRIPTION
Closes #523.

`ObjectRepository::findBy()` `$orderBy` now accepts the PHP 8.6 `SortDirection` enum in addition to the `'asc'`, `'desc'`, `'ASC'` and `'DESC'` strings. The native signature is unchanged and strings remain accepted.

This is a breaking change for implementers of `ObjectRepository`, who cannot declare a more restrictive type for `$orderBy`, so it targets 5.0 only. The companion change on 4.3.x (#524) was closed for that reason.

`symfony/polyfill-php86` is added to `require-dev` so PHPStan can resolve `SortDirection` on PHP 8.4-8.5 without a production dependency. The contract is validated by the static-analysis CI.